### PR TITLE
Update author and maintainers list a bit

### DIFF
--- a/Contacts/People/authors.mixer
+++ b/Contacts/People/authors.mixer
@@ -41,6 +41,7 @@
   <li> <mixer person="Max Horn" data="name_link_city"/> </li>
   <li> <mixer person="Erzebet Horvath" data="name_link_city"/> </li>
   <li> <mixer person="Alexander Hulpke" data="name_link_city"/> </li>
+  <li> <mixer person="Chris Jefferson" data="name_link_city"/> </li>
   <li> <mixer person="Ansgar Kaup" data="name_link_city"/> </li>
   <li> <mixer person="Susanne Keitemeier" data="name_link_city"/> </li>
   <li> <mixer person="Stefan Kohl"  data="name_link_city"/> </li>
@@ -60,6 +61,7 @@
   <li> <mixer person="Alice Niemeyer" data="name_link_city"/> </li>
   <li> <mixer person="Dmitrii Pasechnik" data="name_link_city"/> </li>
   <li> <mixer person="Goetz Pfeiffer" data="name_link_city"/> </li>
+  <li> <mixer person="Markus Pfeiffer" data="name_link_city"/> </li>
   <li> <mixer person="Udo Polis" data="name_link_city"/> </li>
   <li> <mixer person="Ferenc Rakoczi" data="name_link_city"/> </li>
   <li> <mixer person="Sarah Rees" data="name_link_city"/> </li>

--- a/Contacts/People/modules.mixer
+++ b/Contacts/People/modules.mixer
@@ -173,8 +173,7 @@
 
   <li> <strong>Subgroup presentations</strong>
        <em> &nbsp;&nbsp;by Volkmar Felsch, <br />
-       maintained by
-       <mixer person="Werner Nickel" data="name_link_city"/>
+       no official maintainer
        </em><br />
        Subgroup presentations by rewriting.
        <br />&nbsp;
@@ -182,8 +181,7 @@
 
   <li> <strong>Tietze transformations</strong>
        <em> &nbsp;&nbsp;by Volkmar Felsch, <br />
-       maintained by
-       <mixer person="Werner Nickel" data="name_link_city"/>
+       no official maintainer
        </em><br />
        Tietze transformations.
        <br />&nbsp;
@@ -209,7 +207,7 @@
 
   <li> <strong>Random Schreier-Sims</strong>
        <em> &nbsp;&nbsp;by Ákos Seress <br />
-        no official maintainer
+       no official maintainer
        </em><br />
        Random Schreier-Sims and verification routine.
        <br />&nbsp;
@@ -217,7 +215,7 @@
 
   <li> <strong>Permutation group composition series</strong>
        <em> &nbsp;&nbsp;by Ákos Seress <br />
-       no official maintainer 
+       no official maintainer
        </em><br />
        Composition series for permutation groups, PCore, Radical.
        <br />&nbsp;
@@ -226,8 +224,7 @@
   <li> <strong>Multiplier and Schur cover</strong>
        <em> &nbsp;&nbsp;by Werner Nickel and Alexander Hulpke, <br />
        maintained by
-       <mixer person="Alexander Hulpke" data="name_link_city"/> and
-       <mixer person="Werner Nickel" data="name_link_city"/> 
+       <mixer person="Alexander Hulpke" data="name_link_city"/>
        </em><br />
        Calculation of multiplier, Schur Cover epimorphism.
        <br />&nbsp;
@@ -271,9 +268,10 @@
        Werner Nickel, and Martin Schönert,<br />
        maintained by 
        <mixer person="Max Horn" data="name_link_city"/>,
+       <mixer person="Chris Jefferson" data="name_link_city"/>
        <mixer person="Steve Linton" data="name_link_city"/>,
        <mixer person="Frank Luebeck" data="name_link_city"/>, and 
-       <mixer person="Werner Nickel" data="name_link_city"/>
+       <mixer person="Markus Pfeiffer" data="name_link_city"/>
        </em><br />
        Interpreter of GAP-language, user interface, memory management,
        basic data structures and basic operations for them.
@@ -292,8 +290,7 @@
 
   <li> <strong>Automorphism groups of finite pc groups</strong>
        <em> &nbsp;&nbsp;by Bettina Eick, <br />
-       maintained by
-       <mixer person="Werner Nickel" data="name_link_city"/>
+       no official maintainer
        </em><br />
        This module contains an algorithm to determine the automorphism
        group of a finite pc group. The implementation follows the ideas
@@ -335,8 +332,7 @@
 
   <li> <strong>Properties and attributes of finite pc groups</strong>
        <em> &nbsp;&nbsp;by Frank Celler and Bettina Eick, <br />
-       maintained by
-       <mixer person="Werner Nickel" data="name_link_city"/>
+       no official maintainer
        </em><br />
        This module contains algorithm to test certain properties
        and compute certain attributes of finite pc groups.
@@ -345,8 +341,7 @@
 
   <li> <strong>Intersection of subgroups of finite pc groups</strong>
        <em> &nbsp;&nbsp;by Frank Celler and Bettina Eick, <br />
-       maintained by
-       <mixer person="Werner Nickel" data="name_link_city"/>
+       no official maintainer
        </em><br />
        This module contains an algorithm to compute the intersection
        of subgroups of finite pc groups.

--- a/lib/addresses
+++ b/lib/addresses
@@ -642,11 +642,16 @@
 
 <person id="Chris Jefferson"
     name       = "Chris Jefferson"
-    www        = "https://caj.host.cs.st-andrews.ac.uk/"
+    title      = "Dr."
+    department = "School of Computer Science"
     university = "University of St Andrews"
-    department = " School of Computer Science"
+    street     = "North Haugh"
     city       = "St Andrews"
+    county     = "Fife"
+    zipcode    = "KY16 9SS"
     country    = "UK"
+    email      = "caj21@st-andrews.ac.uk"
+    www        = "http://caj.host.cs.st-andrews.ac.uk/"
 />
 
 <person id="D. Johnson"
@@ -1136,6 +1141,20 @@
     university = "University College Galway"
     city       = "Galway"
     country    = "Ireland"
+/>
+
+<person id="Markus Pfeiffer"
+    name       = "Markus Pfeiffer"
+    title      = "Dr."
+    department = "School of Computer Science"
+    university = "University of St Andrews"
+    street     = "North Haugh"
+    city       = "St Andrews"
+    county     = "Fife"
+    zipcode    = "KY16 9SS"
+    country    = "UK"
+    email      = "markusp@mcs.st-andrews.ac.uk"
+    www        = "http://www.morphism.de/~markusp"
 />
 
 <person id="Wilhelm Plesken"


### PR DESCRIPTION
This adds @ChrisJefferson and @markuspf to the author lists, and also adds them to the list of kernel maintainers; it also removes Werner Nickel from the list of maintainers.

In general, the lists of persons contains many outdated addresses; and I am also somewhat doubtful about some of the module maintainers still listed... But with this it is at least a little bit better.