### PR TITLE
Mention C++ compiler is recommended

### DIFF
--- a/Download/tools.mixer
+++ b/Download/tools.mixer
@@ -9,9 +9,9 @@ for Windows or rsync installations) will require a working C
 development environment on your system. This should include a C
 compiler (preferably gcc 4.2 or higher), make, binary utilities such
 as a linker, and development libraries.  We recommend that you also
-install a C++ compiler, as various GAP packages require one. The
-GAP build system will enable special support for such packages
-if the presence of a C++ compiler is detected while building GAP.
+install a C++ compiler, as various <mixer var="GAP"/> packages require one. The
+<mixer var="GAP"/> build system will enable special support for such packages
+if the presence of a C++ compiler is detected while building <mixer var="GAP"/>.
 You will also need the m4 macro processor; most, but not all standard
 development environments include this. Furthermore, if the readline
 library is detected on your system at compile time, it will be used

--- a/Download/tools.mixer
+++ b/Download/tools.mixer
@@ -8,9 +8,11 @@ and full data libraries takes about 1.2 GB of disk space and (except
 for Windows or rsync installations) will require a working C
 development environment on your system. This should include a C
 compiler (preferably gcc 4.2 or higher), make, binary utilities such
-as a linker, and development libraries.  You will also need the m4
-macro processor to be able to build <mixer var="GAP"/> with GMP
-support for faster large integer arithmetic; most, but not all standard
+as a linker, and development libraries.  We recommend that you also
+install a C++ compiler, as various GAP packages require one. The
+GAP build system will enable special support for such packages
+if the presence of a C++ compiler is detected while building GAP.
+You will also need the m4 macro processor; most, but not all standard
 development environments include this. Furthermore, if the readline
 library is detected on your system at compile time, it will be used
 for command line editing.


### PR DESCRIPTION
Also remove a reference to GMP, as we soon will *always* require GMP.