### PR TITLE
Add Gabor Horvath as StructureDescription module author

### DIFF
--- a/Contacts/People/modules.mixer
+++ b/Contacts/People/modules.mixer
@@ -499,7 +499,7 @@
   </li>
 
   <li> <strong>Structure Descriptions for Finite Groups</strong>
-       <em> &nbsp;&nbsp;<br/>by Stefan Kohl, Markus P�schel and
+       <em> &nbsp;&nbsp;<br/>by Gábor Horváth, Stefan Kohl, Markus Püschel and
        Sebastian Egner,<br />
        maintained by 
        <mixer person="Gabor Horvath" data="name_link_city"/> and


### PR DESCRIPTION
Update website with me being not only maintainer but also author of the module. (I hope I put it into the appropriate file, I was thinking about the bottom of the site http://gap-system.org/Contacts/People/modules.html )