### PR TITLE
Update tools with distribution package depends

### DIFF
--- a/Download/tools.mixer
+++ b/Download/tools.mixer
@@ -56,14 +56,18 @@ development tools) although they are not required for basic operation.
 For example, 
 <dl>
 <dt><a href="../Packages/browse.html">Browse</a></dt>
-	<dd>needs the ncurses library;</dd>
+	<dd>needs the ncurses library
+	(e.g. libncurses5-dev and libncursesw5-dev);</dd>
 <dt><a href="../Packages/nq.html">nq</a></dt>
-	<dd> needs some version of awk;</dd>
+	<dd> needs some version of awk
+	(e.g. gawk or mawk);</dd>
 <dt><a href="../Packages/fr.html">FR</a></dt>
 	<dd> may need wget;</dd>
 <dt><a href="../Packages/xgap.html">XGAP</a></dt>
 	<dd>requires the following X11 libraries: libXaw, libXmu, libXt,
-	libXext, libX11, libSM, and libICE;</dd>
+	libXext, libX11, libSM, and libICE
+	(e.g. libx11-dev, libxaw7-dev, libxt-dev which possibly aready install
+	the other four libxmu-dev, libxext-dev, libsm-dev, libice-dev);</dd>
 <dt><a href="../Packages/pargap.html">ParGAP</a></dt>
 	<dd> needs an MPI implementation such as OpenMPI or MPICH2
 	but optionally may use the MPINU library supplied with the package.</dd>


### PR DESCRIPTION
This updates the page http://www.gap-system.org/Download/tools.html with some Ubuntu/Debian based dependencies that might help newcomers with building packages properly. 

I believe that this page should be kept uptodate and I feel that it should mainly be the package authors responsibility to help keeping this website always current and updated. We should not expect a newcomer to GAP or to linux knowing what _development_ packages they need to install for e.g. xgap when the manual only says "X window system in the Version 11 Release 5 or newer".... (Anyway, after some thinking and trial-and-error, I figured it out from the output of ````BuildPackages.sh```` and this website).

I have not checked ParGAP, yet, and as of now, I have failed to build float, fr, linboxing, NormalizInterface-0.9.8, PolymakeInterface. I might update this PR after some further investigation, but it should not halt merging if and when the PR found to be ready for that.