### PR TITLE
Revised list of alternative ways to use GAP

### DIFF
--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -119,20 +119,6 @@ distribution whereas <mixer var="GAP"/>4.4.9 is only in the
 </p>
 
 <h3>
-  <mixer var="GAP"/> FTP Server
-</h3>
-<p>
-  You can use anonymous ftp. The following ftp server carries the
-  official <mixer var="GAP"/> distribution:
-</p>
-<ul>
-  <li>
-    <a href="ftp://ftp.gap-system.org/pub/gap">
-    ftp://ftp.gap-system.org/pub/gap</a> St Andrews, UK
-  </li>
-</ul>
-
-<h3>
   Trying <mixer var="GAP"/>
 </h3>
 <p>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -14,9 +14,7 @@
   packages. If you install <mixer var="GAP"/>  as described on the page 
   <a href="/Download/index.html">Downloading&nbsp;and&nbsp;Installing&nbsp;<mixer var="GAP4"/></a>,
   then after compiling the core <mixer var="GAP"/> system you have to run in the 
-  <code>pkg</code> subdirectory the shell script 
-  <a href="../Download/InstPackages.sh"><code>InstPackages.sh</code></a> 
-  or <a href="../Download/InstPackages32.sh"><code>InstPackages32.sh</code></a>
+  <code>pkg</code> subdirectory the shell script <code>../bin/BuildPackages.sh</code>
   in order to build most of the packages that require compilation provided 
   sufficiently many libraries, headers and tools are available.
 </p>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -46,16 +46,7 @@ brew upgrade gap
 </pre>
 This may take some time, so please be patient.
 
-<h3>
-  BOB
-</h3>
-<p>
-<a href="http://gap-system.github.io/bob/">BOB</a> is a tool developed by
-<a href="http://www-groups.mcs.st-and.ac.uk/~neunhoef/index.html">Max Neunh&ouml;ffer</a>
-to download and build <mixer var="GAP"/> and its packages from source on Linux and OS X.
-You need a C-compiler and some libraries installed on your system but BOB will
-tell you exactly what is missing.
-</p>
+
 
 <h3>
   Docker
@@ -81,16 +72,6 @@ docker run --rm -i -t gapsystem/gap-docker gap
 to start <mixer var="GAP"/>. Note that you may have to run it with sudo,
 particularly if you are on Ubuntu. Further instructions could be found
 <a href="https://hub.docker.com/r/gapsystem/gap-docker/">here</a>.
-</p>
-
-<h3>
-  <mixer var="GAP"/> Rsync
-</h3>
-<p>
-<mixer person="Frank Luebeck" data="name_link"/>  offers  a
-<a href="http://www.math.rwth-aachen.de/~Frank.Luebeck/gap/rsync">Linux 
-binary distribution</a> via remote syncronization with a reference 
-installation which includes all packages and some optimisations. 
 </p>
 
 <!--
@@ -125,6 +106,35 @@ distribution whereas <mixer var="GAP"/>4.4.9 is only in the
   We do not normally produce CDs containing <mixer var="GAP"/>.
   In the exceptional case when you are unable to get <mixer var="GAP"/> any
   other way, please contact us at <mixer person="GAP" data="email_link"/>.
+</p>
+
+<br />
+
+<h2>
+  Not updated at the moment
+</h2>
+
+<h3>
+  BOB
+</h3>
+<p>
+<a href="http://gap-system.github.io/bob/">BOB</a> is a tool developed by
+<a href="http://www-groups.mcs.st-and.ac.uk/~neunhoef/index.html">Max Neunh&ouml;ffer</a>
+to download and build <mixer var="GAP"/> and its packages from source on Linux and OS X.
+It required a C-compiler and some libraries installed on the system, and was able to
+tell exactly which dependencies were missing. The last <mixer var="GAP"/> release provided
+by BOB was GAP 4.7.9.
+</p>
+
+<h3>
+  <mixer var="GAP"/> Rsync
+</h3>
+<p>
+<mixer person="Frank Luebeck" data="name_link"/>  has been offering a
+<a href="http://www.math.rwth-aachen.de/~Frank.Luebeck/gap/rsync">Linux
+binary distribution</a> via remote syncronization with a reference
+installation which includes all packages and some optimisations.
+The last <mixer var="GAP"/> release provided by this service was GAP 4.7.6.
 </p>
 
 </mixer>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -20,9 +20,11 @@
 </p>
 
 <p>
-  You might want to consider one of the alternative installation methods 
-  below which simplify the installation of <mixer var="GAP"/> and its packages 
-  by further automation or by offering precompiled binaries.
+  You might want to consider one of the alternative installation methods
+  below which simplify the installation of <mixer var="GAP"/> and its packages
+  by further automation or by offering precompiled binaries. Please note that
+  these alternatives may not provide access to the latest public <mixer var="GAP"/>
+  release, and it may take a while until they will be updated.
 </p>
 
 <h3>
@@ -95,6 +97,17 @@ distribution whereas <mixer var="GAP"/>4.4.9 is only in the
 <p>
   If you cannot download <mixer var="GAP"/> directly from the web pages,
   there are some further alternatives.
+</p>
+
+<h3>
+  Trying <mixer var="GAP"/> on SageMathCloud
+</h3>
+<p>
+  It is possible to use <mixer var="GAP"/> via a free account on
+  <a href="https://cloud.sagemath.com/">SageMathCloud</a>.
+  Please be aware that the combination of  <mixer var="GAP"/>
+  packages available there may differ from the one from the
+  official <mixer var="GAP"/> distribution.
 </p>
 
 <h3>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -119,18 +119,6 @@ distribution whereas <mixer var="GAP"/>4.4.9 is only in the
 </p>
 
 <h3>
-  Trying <mixer var="GAP"/>
-</h3>
-<p>
-  It is possible to get an account in the <b>MEDICIS</b> computers in
-  order to try <mixer var="GAP"/>, as well as other computer algebra
-  systems. To get more information you can read their
-  <a href="http://www.medicis.polytechnique.fr">web&nbsp;page</a>
-  or send an
-  <a href="mailto:assistance@medicis.polytechnique.fr">email</a>.
-</p>
-
-<h3>
   <mixer var="GAP"/> on CDs
 </h3>
 <p>


### PR DESCRIPTION
This morning I've got an email from a user telling he can't download GAP 4.8.7 from an FTP server. It happens that FTP was in his old script, not on the GAP website. Anyhow, this triggered issue #32 and revising the alternatives page (https://www.gap-system.org/Download/alternatives.html) in this PR.