### PR TITLE
Change more links from http:// to https://

### DIFF
--- a/Contacts/Forum/forum.mixer
+++ b/Contacts/Forum/forum.mixer
@@ -28,7 +28,7 @@
 <p>
   To subscribe to the Forum, to change your email address for correspondence
   with the Forum, or to leave the Forum, please use the
-  <a href="http://mail.gap-system.org/mailman/listinfo/forum">
+  <a href="https://mail.gap-system.org/mailman/listinfo/forum">
   mailman&nbsp;page</a> provided for this purpose. Once you are subscribed,
   this page will also allow you to obtain a list of the email addresses
   of the Forum members.

--- a/Doc/forumarchive.mixer
+++ b/Doc/forumarchive.mixer
@@ -11,7 +11,7 @@
   'mailman' program. Its contents can be obtained in the
 </p>
 <p>
-  <a href="http://mail.gap-system.org/pipermail/forum/">
+  <a href="https://mail.gap-system.org/pipermail/forum/">
   Archive&nbsp;of&nbsp;postings&nbsp;since&nbsp;December&nbsp;2003</a>.
 </p>
 <p>
@@ -105,7 +105,7 @@
 <p>
   If you want to participate in the discussion in the Forum you have to
   subscribe to it. For this you can use the
-  <a href="http://mail.gap-system.org/mailman/listinfo/forum">
+  <a href="https://mail.gap-system.org/mailman/listinfo/forum">
   mailman&nbsp;page</a>.
 </p>
 <p>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -129,7 +129,7 @@ distribution whereas <mixer var="GAP"/>4.4.9 is only in the
   BOB
 </h3>
 <p>
-<a href="http://gap-system.github.io/bob/">BOB</a> is a tool developed by
+<a href="https://gap-system.github.io/bob/">BOB</a> is a tool developed by
 <a href="http://www-groups.mcs.st-and.ac.uk/~neunhoef/index.html">Max Neunh&ouml;ffer</a>
 to download and build <mixer var="GAP"/> and its packages from source on Linux and OS X.
 It required a C-compiler and some libraries installed on the system, and was able to

--- a/Download/index.mixer
+++ b/Download/index.mixer
@@ -116,7 +116,7 @@ reference installation which includes all packages and some optimisations.
 <li>
 <a href="http://www-groups.mcs.st-and.ac.uk/~neunhoef/index.html">Max
 Neunh&ouml;ffer</a> offers 
-<a href="http://gap-system.github.io/bob/">
+<a href="https://gap-system.github.io/bob/">
 BOB - a tool to download and build GAP and its packages from source</a> 
 for Linux and Mac OS X.
 You only download BOB who does all the rest for you. You need
@@ -268,7 +268,7 @@ as you would cite an article or book (see recommended
 </p>
 
 <p>All <mixer var="GAP"/> users are invited to join the 
-<a href="http://mail.gap-system.org/mailman/listinfo/forum">GAP Forum mailing list</a> 
+<a href="https://mail.gap-system.org/mailman/listinfo/forum">GAP Forum mailing list</a> 
 on mathematical and programming questions concerning <mixer var="GAP"/>. 
 Announcements of bugfixes, new versions and new packages are also sent to that list.
 </p>

--- a/Faq/faq.mixer
+++ b/Faq/faq.mixer
@@ -1416,7 +1416,7 @@ This example point to an important consequence: lookup in b is much faster
 than searching in a, since, as b is known to be sorted, binary search is used
 for the lookup.  An amusing instance of a painful learning experience in the
 subject appears in the Forum thread starting in
-<a href="http://mail.gap-system.org/pipermail/forum/2008/002169.html">http://mail.gap-system.org/pipermail/forum/2008/002169.html</a>.
+<a href="https://mail.gap-system.org/pipermail/forum/2008/002169.html">https://mail.gap-system.org/pipermail/forum/2008/002169.html</a>.
 </p>
 </li>
 </ul>
@@ -2230,7 +2230,7 @@ external C programs, and it is only possible to use it under Unix or Linux."
 </p>
 <p>
 However in a further
-<a href="http://mail.gap-system.org/pipermail/forum/2004/000926.html">
+<a href="https://mail.gap-system.org/pipermail/forum/2004/000926.html">
 letter</a>   Dima Pasechnik added:
 </p>
 <p>

--- a/Releases/4.7.6.mixer
+++ b/Releases/4.7.6.mixer
@@ -52,7 +52,7 @@ the desciption of all installation options in the <a href="../Download/INSTALL">
 You may also consider one of the 
 <a href="../Download/alternatives.html">alternative distributions</a>,
 namely <a href="http://www.math.rwth-aachen.de/~Frank.Luebeck/gap/rsync"><mixer var="GAP"/> Rsync</a> or 
-<a href="http://gap-system.github.io/bob/">BOB</a>. Note, however, that these are updated independently 
+<a href="https://gap-system.github.io/bob/">BOB</a>. Note, however, that these are updated independently 
 and may not yet provide the latest <mixer var="GAP"/> release.
 </p>
 

--- a/Releases/4.7.7.mixer
+++ b/Releases/4.7.7.mixer
@@ -52,7 +52,7 @@ the desciption of all installation options in the <a href="../Download/INSTALL">
 You may also consider one of the 
 <a href="../Download/alternatives.html">alternative distributions</a>,
 namely <a href="http://www.math.rwth-aachen.de/~Frank.Luebeck/gap/rsync"><mixer var="GAP"/> Rsync</a> or 
-<a href="http://gap-system.github.io/bob/">BOB</a>. Note, however, that these are updated independently 
+<a href="https://gap-system.github.io/bob/">BOB</a>. Note, however, that these are updated independently 
 and may not yet provide the latest <mixer var="GAP"/> release.
 </p>
 

--- a/gap.mixer
+++ b/gap.mixer
@@ -13,7 +13,7 @@
 <p class="center">
 <!--
 The first public release of <mixer var="GAP"/> 4.5 was made on June 15th 2012
-(see <a href="http://mail.gap-system.org/pipermail/forum/2012/003707.html">here</a>). <br /><br />
+(see <a href="https://mail.gap-system.org/pipermail/forum/2012/003707.html">here</a>). <br /><br />
 -->
 The current version is 
 <a href="Releases/index.html"><mixer var="GAP"/>&nbsp;4<mixer var="rel4long"/>.<mixer var="fix4level"/></a> 
@@ -76,7 +76,7 @@ Software Engineering applied to Computer Algebra</i>.
   <a href="https://github.com/gap-system/gap/blob/master/CONTRIBUTING.md">here</a>.
   If you have any questions, or suggestions for <mixer var="GAP"/>, the repository,
   or documentation, feel free to contact us via the
-  <a href="http://mail.gap-system.org/mailman/listinfo/gap">open GAP development mailing list</a>
+  <a href="https://mail.gap-system.org/mailman/listinfo/gap">open GAP development mailing list</a>
   or submit an issue or a pull request on GitHub.
 </p>
 <p>
@@ -94,7 +94,7 @@ Software Engineering applied to Computer Algebra</i>.
   with the <mixer var="GAP"/> users and offers support for them. 
   To keep up to date on <mixer var="GAP"/> news (discussion of
   problems, release announcements, bug fixes), we suggest you to
-  <a href="http://mail.gap-system.org/mailman/listinfo/forum">subscribe</a>
+  <a href="https://mail.gap-system.org/mailman/listinfo/forum">subscribe</a>
   to the email-based
   <a href="/Contacts/Forum/forum.html"><mixer var="GAP"/>&nbsp;Forum</a>.
   You may also follow <mixer var="GAP"/> on <a href="http://twitter.com/gap_system">Twitter</a>.

--- a/search.mixer
+++ b/search.mixer
@@ -30,7 +30,7 @@ Here and below, to enforce the search of a particular command, you may need to e
 Please note that GAP Forum Archives since December 2003 are not covered by the complete GAP website search above
 </p>
 <form action="https://google.com/search" method="get">
-<input type="hidden" name="sitesearch" value="http://mail.gap-system.org/pipermail/forum/" />
+<input type="hidden" name="sitesearch" value="https://mail.gap-system.org/pipermail/forum/" />
 <input type="text" size="60" name="query" />
 <button type="submit">Search</button>
 </form>


### PR DESCRIPTION
This fixes links to the mailing list archives, which do not work anymore via http.