### PR TITLE
update Gap.app description and links

### DIFF
--- a/Packages/undep.mixer
+++ b/Packages/undep.mixer
@@ -486,11 +486,12 @@ For more information on the Sage notebook or the Sage interface with GAP, please
 </li>
 
 <li>
-<b>gap.app</b>: Written by <a href="http://www.math.wustl.edu/~russw/">Russ Woodroofe</a>, 
-this is an alternative to XGAP and only works on Macs.
-(It has not been tested with Mac OS X 10.7, nor with GAP 4.5.)
-See <a href="http://cocoagap.sourceforge.net/">http://cocoagap.sourceforge.net/</a>. This program was called cocoaGAP, but the
-name was changed to avoid confusion with the computer algebra system Cocoa.
+<b>Gap.app</b>: Written by <a href="http://osebje.famnit.upr.si/~russ.woodroofe/">Russ Woodroofe</a>, 
+this Mac-only program is a front-end to GAP.  The "Gap.app+GAP" download contains an entire installation of GAP 
+inside the .app bundle for drag-and-drop GAP installation (of version 4.9.1 as of this writing).
+Gap.app is fully compatible with XGAP, 
+and provides a Mac-like interface for GAP.  Tested on macOS 10.12 and 10.13.
+See <a href="https://cocoagap.sourceforge.io/">https://cocoagap.sourceforge.io/</a>.  
 </li>
 
 </ul>


### PR DESCRIPTION
The Gap.app description was out-of-date, and the links provided were old.  Updated to indicate that it works with recent GAP versions and macOS versions, and that it's more than an XGAP clone.

I tried to keep a neutral tone, but am not offended by edits if I failed.