### PR TITLE
remove Gap.app from undeposited; add it instead to alternative distributions

### DIFF
--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -59,8 +59,8 @@ particularly if you are on Ubuntu. Further instructions could be found
 <p>
 <a href="https://cocoagap.sourceforge.io/">Gap.app</a> is a native macOS frontend
 and distribution of GAP, developed by Russ Woodroofe.  The Gapdotapp+GAP edition
-includes a full copy of GAP, which can be installed by simply downloading a disk
-image and dragging Gap.app to the Applications folder.  You can also install the
+includes a fairly complete copy of GAP, and can be installed by simply downloading a
+disk image and dragging Gap.app to the Applications folder.  You can also install the
 GAP for use from your usual terminal via the Install GAP Command For Shell menu option
 (found under the Gap menu in the GUI frontend).
 </p>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -65,7 +65,9 @@ it for use in Terminal.app via the Install GAP Command For Shell menu option
 (found under the Gap menu in the GUI frontend).
 </p>
 <p>The included GAP comes with working copies of most of the packages in the
-standard GAP distribution.  It may lag slightly behind the very latest GAP version.
+standard GAP distribution.  Gap.app is compatible with XGAP, and allows interactive display
+of subgroup lattices with the <code>GraphicSubgroupLattice</code> command. 
+The version of GAP may lag slightly behind the very latest.
 Full details on the currently-included GAP may be found in the 
   <a href="https://cocoagap.sourceforge.io/faq.html#gapversioninfo">Gap.app FAQ</a>.
 </p>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -60,14 +60,14 @@ particularly if you are on Ubuntu. Further instructions could be found
 <a href="https://cocoagap.sourceforge.io/">Gap.app</a> is a native macOS frontend
 and distribution of GAP, developed by Russ Woodroofe.  The Gapdotapp+GAP edition
 includes a full copy of GAP, which can be installed by simply downloading a disk
-image, and dragging Gap.app to the Applications folder.  You can also install the
-it for use in Terminal.app via the Install GAP Command For Shell menu option
+image and dragging Gap.app to the Applications folder.  You can also install the
+GAP for use from your usual terminal via the Install GAP Command For Shell menu option
 (found under the Gap menu in the GUI frontend).
 </p>
 <p>The included GAP comes with working copies of most of the packages in the
 standard GAP distribution.  Gap.app is compatible with XGAP, and allows interactive display
 of subgroup lattices with the <code>GraphicSubgroupLattice</code> command. 
-The version of GAP may lag slightly behind the very latest.
+The version of GAP that comes with Gap.app may lag slightly behind the very latest.
 Full details on the currently-included GAP may be found in the 
   <a href="https://cocoagap.sourceforge.io/faq.html#gapversioninfo">Gap.app FAQ</a>.
 </p>

--- a/Download/alternatives.mixer
+++ b/Download/alternatives.mixer
@@ -52,6 +52,24 @@ to start <mixer var="GAP"/>. Note that you may have to run it with sudo,
 particularly if you are on Ubuntu. Further instructions could be found
 <a href="https://hub.docker.com/r/gapsystem/gap-docker/">here</a>.
 </p>
+  
+<h3>
+  Gap.app (macOS only)
+</h3>
+<p>
+<a href="https://cocoagap.sourceforge.io/">Gap.app</a> is a native macOS frontend
+and distribution of GAP, developed by Russ Woodroofe.  The Gapdotapp+GAP edition
+includes a full copy of GAP, which can be installed by simply downloading a disk
+image, and dragging Gap.app to the Applications folder.  You can also install the
+it for use in Terminal.app via the Install GAP Command For Shell menu option
+(found under the Gap menu in the GUI frontend).
+</p>
+<p>The included GAP comes with working copies of most of the packages in the
+standard GAP distribution.  It may lag slightly behind the very latest GAP version.
+Full details on the currently-included GAP may be found in the 
+  <a href="https://cocoagap.sourceforge.io/faq.html#gapversioninfo">Gap.app FAQ</a>.
+</p>
+
 
 <!--
 <h3>

--- a/Packages/undep.mixer
+++ b/Packages/undep.mixer
@@ -502,15 +502,6 @@ For more information on the Sage notebook or the Sage interface with GAP, please
 <a href="http://doc.sagemath.org/html/en/reference/">Sage Reference Manual</a>.
 </li>
 
-<li>
-<b>Gap.app</b>: Written by <a href="http://osebje.famnit.upr.si/~russ.woodroofe/">Russ Woodroofe</a>, 
-this Mac-only program is a front-end to GAP.  The "Gap.app+GAP" download contains an entire installation of GAP 
-inside the .app bundle for drag-and-drop GAP installation (of version 4.9.1 as of this writing).
-Gap.app is fully compatible with XGAP, 
-and provides a Mac-like interface for GAP.  Tested on macOS 10.12 and 10.13.
-See <a href="https://cocoagap.sourceforge.io/">https://cocoagap.sourceforge.io/</a>.  
-</li>
-
 </ul>
 
 </mixer>


### PR DESCRIPTION
This is following a suggestion of Alexander Konavalov.