### PR TITLE
Update a link to an ancient FAQ copy

### DIFF
--- a/lib/gwstart.tmpl
+++ b/lib/gwstart.tmpl
@@ -51,7 +51,7 @@
 <a href="sitemap.html" class="deepestchildren">Sitemap</a>
 </td></tr>-->
 <tr><td>&nbsp;&nbsp;
-<a href="/Faq/General/general5.html" class="deepestchildren">
+<a href="/Faq/faq.html#1.5" class="deepestchildren">
          Site&nbsp;Structure</a>
 </td></tr>
 <tr><td>&nbsp;&nbsp;


### PR DESCRIPTION
@ChrisJefferson noticed a seemingly "broken" FAQ page. This was caused by an outdated link which points to an ancient version of the FAQ. This PR updates that link. But in addition, it would be good to remove the outdated FAQ from the server.