### PR TITLE
Fix displaying title at top of content

### DIFF
--- a/_layouts/default.hml
+++ b/_layouts/default.hml
@@ -26,7 +26,7 @@ layout: core
 <mixer func="makeleft_plus"/></td><!-- TODO -->
 
 <td class="content">
-<h2>{{ title }}</h2>
+<h2>{{ page.title }}</h2>
 {{ content }}
 </td>
 


### PR DESCRIPTION
Fixes a mistake in default.html (title instead of page.title), which makes the title of the page also appear at the top of the text.