### PR TITLE
Changed a link in Download/index.html

### DIFF
--- a/Download/index.html
+++ b/Download/index.html
@@ -178,7 +178,7 @@ in this order:
 </p>
 <ul>
 <li>Look at the "If Things Go Wrong" section of the
-<a href="https://github.com/gap-system/gap/blob/v{{relversion}}/INSTALL.md">GAP {{site.data.gap.relversion}} Installation Instructions</a>,
+<a href="https://github.com/gap-system/gap/blob/master/INSTALL.md">GAP {{site.data.gap.relversion}} Installation Instructions</a>,
 it contains some additional remarks and troubleshooting advices.</li>
 <li>Tell us about your problem by writing an email to <a
 href="mailto:support@gap-system.org">support@gap-system.org</a>.</li>


### PR DESCRIPTION
Now if things go wrong your are linked to the installation instructions of the master branch of GAP