### PR TITLE
Datalib: replace symlinks with redirections

### DIFF
--- a/Datalib/prim.html
+++ b/Datalib/prim.html
@@ -1,1 +1,8 @@
-../Packages/primgrp.html
+---
+title: GAP Data Library "Primitive Groups"
+layout: default
+---
+
+<p>
+  This is now in the GAP package <a href="/Packages/primgrp.html">primgrp</a>.
+</p>

--- a/Datalib/tom.html
+++ b/Datalib/tom.html
@@ -1,1 +1,8 @@
-../Packages/tomlib.html
+---
+title: GAP Data Library "Tables of Marks"
+layout: default
+---
+
+<p>
+  This is now in the GAP package <a href="/Packages/tomlib.html">tomlib</a>.
+</p>

--- a/Datalib/trans.html
+++ b/Datalib/trans.html
@@ -1,1 +1,8 @@
-../Packages/transgrp.html
+---
+title: GAP Data Library "Transitive Groups"
+layout: default
+---
+
+<p>
+  This is now in the GAP package <a href="/Packages/transgrp.html">transgrp</a>.
+</p>


### PR DESCRIPTION
The symlinks resulted in very strange things. Like, take a look at https://www.gap-system.org/Datalib/trans.html it is identical to https://www.gap-system.org/Packages/transgrp.html which is weird.

The alternative would be to turn these pages into redirects, but that also seems iffy... Then again, these pages don't turn up in the navigation (and that's good, IMHO!) but there *are* links to it inside our site: from the Faq and from Gap3...
