### PR TITLE
Jekyll: don't mention SuggestUpgrades

### DIFF
--- a/Download/upgrade.html
+++ b/Download/upgrade.html
@@ -58,24 +58,3 @@ Finally, if you have used one of the
 to install GAP, then you should check their update 
 instructions to find out how to update your installation.
 </p>
-
-<h4>Checking if you need to upgrade</h4>
-
-<p>
-If you run GAP from your installation you can copy and
-paste the following lines into that session to produce suggestions 
-for possible upgrades. In particular, this will produce a list all packages
-having redistributed with GAP versions newer than those in
-your installation.
-</p>
-<p>
-Note that if you have any version of GAP older than the
-<a href="/Releases/{{site.data.gap.relversion}}.html">most recent public release</a>,
-the only way to install a new version of GAP
-is a <a href="index.html">new installation</a>.
-</p>
- 
-<pre>
-   SuggestUpgrades([<mixer parsevar="PKG_SuggestUpgradeLines"/>      ]);
-</pre>
-


### PR DESCRIPTION
It's an outmoded model of working; I'd rather improve PackageManager and suggest *that* to people.

This is part of content cleanup, I guess