### PR TITLE
Fix screen width when outputting some GAP bibliography pages

### DIFF
--- a/Doc/Bib/convbib.g
+++ b/Doc/Bib/convbib.g
@@ -190,6 +190,9 @@ bib2niceandhtml := function(name, header, subheader)
        " pdflatex FLtmpTeX; mv FLtmpTeX.pdf ",name,".pdf; rm -f FLtmpTeX.* ",name,"nicertmp.bib"));
 end;
 
+# set fixed screen size to avoid formatting changes in fh()  output
+SizeScreen([139,]);
+
 # Add further lists here.
 bib2niceandhtml("gap-published", "Published work which cites GAP",
 Concatenation( "The GAP bibliography was partially obtained using the ",

--- a/_data/bib_stats_msc.yml
+++ b/_data/bib_stats_msc.yml
@@ -3,7 +3,7 @@
 # Area/Primary/Secondary
 
 - code: "00"
-  name: General
+  name: General and overarching topics; collections
   primary: 5
   secondary: 1
 
@@ -43,7 +43,7 @@
   secondary: 24
 
 - code: "13"
-  name: Commutative rings and algebras
+  name: Commutative algebra
   primary: 24
   secondary: 28
 
@@ -133,7 +133,7 @@
   secondary: 1
 
 - code: "42"
-  name: Fourier analysis
+  name: Harmonic analysis on Euclidean spaces
   primary: 3
   secondary: 0
 
@@ -253,7 +253,7 @@
   secondary: 10
 
 - code: "91"
-  name: Game theory, economics, social and behavioral sciences
+  name: Game theory, economics, finance, and other social and behavioral sciences
   primary: 1
   secondary: 0
 
@@ -268,7 +268,7 @@
   secondary: 0
 
 - code: "94"
-  name: Information and communication, circuits
+  name: Information and communication theory, circuits
   primary: 89
   secondary: 43
 


### PR DESCRIPTION
I have figured out the reason of those seemingly random changes I observed a couple of days in a row while working on `Doc/Bib` content. This will avoid them by fixing the screen width. 

This regenerates one of the data file (should be done as a part of my previous PR).