### PR TITLE
Updates of GAP use in teaching page

### DIFF
--- a/Doc/Learning/learning.html
+++ b/Doc/Learning/learning.html
@@ -147,7 +147,11 @@ Of this the section 'Graph Theory using the GRAPE package' was contributed by
     written an explanation how to create new objects in GAP using the example
     of <a href="http://www.cs.st-andrews.ac.uk/~alexk/circle/chap2.html">circle
     multiplication</a>.
-
+    <br />&nbsp;
+  </li>
+  <li>
+    <a href="https://mat.ug.edu.pl/~rlutowsk/pub/gap-short.pdf">GAP – bardzo krótkie wprowadzenie</a>
+    (a brief introduction to GAP in Polish) by Rafał Lutowski (University of Gdańsk, Poland).
     <br />&nbsp;
   </li>
 

--- a/Doc/Teaching/teaching.html
+++ b/Doc/Teaching/teaching.html
@@ -47,6 +47,19 @@ toc: Documentation
     Groups given by Presentations, Stabilizer chains, Coset Enumeration (with updates in 2020).
     <br />&nbsp;
   </li>
+  <li>
+    The book <a href="https://global.oup.com/academic/product/an-invitation-to-computational-homotopy-9780198832980">"An Invitation to Computational Homotopy"</a>
+    by Graham Ellis (Oxford University Press, 2019) is using the author's Homological Algebra Programming (HAP) package, redistributed with GAP.<br />&nbsp;
+  </li>
+  <li>
+    The book <a href="https://www.springer.com/gp/book/9783319942254">"Computer Algebra and Materials Physics"</a>
+    by Akihito Kikuchi (Springer, 2018) uses GAP to explain how to use computer algebra for applications in
+    solid-state simulation.<br />&nbsp;
+  </li>
+  <li>
+    <a href="http://lib.brsu.by/sites/default/files/books/%D0%9A%D0%BE%D0%BC%D0%BF%D1%8C%D1%8E%D1%82%D0%B5%D1%80%D0%BD%D0%B0%D1%8F%20%D0%B0%D0%BB%D0%B3%D0%B5%D0%B1%D1%80%D0%B0_2.pdf">"Computer Algebra"</a> -
+    teaching material in Russian by D. V. Gritsuk and A. A. Trofimuk (Brest State A. S. Pushkin University, Belarus, 2018).<br/>&nbsp;
+  </li>
   <li> 
     M. D'Anna, V. Micale and <a href="https://www.ugr.es/~pedro">P. A. García Sánchez</a> gave the course
     <a href="http://www.scuolasuperiorecatania.it/it/semigruppi-numerici-e-applicazioni-0">"Semigruppi numerici e applicazioni"</a>
@@ -55,6 +68,11 @@ toc: Documentation
     <a href="https://github.com/pedritomelenas/SSC-Semigroups">This repository</a> contains a 
     <a href="https://pedritomelenas.github.io/SSC-Semigroups/Live/gap-numericalsgps-thebelab.html">live tutorial of NumericalSgps</a>
     using <a href="https://github.com/executablebooks/thebe">Thebe</a>.<br/>&nbsp;
+  </li>
+  <li>
+    The book <a href="https://www.springer.com/gp/book/9783319823256">"Numerical Semigroups and Applications"</a>
+    by Abdallah Assi and <a href="https://www.ugr.es/~pedro">Pedro A. García Sánchez</a> (Springer, 2016) contains
+    many examples and tutorials with the NumericalsSps GAP package.<br />&nbsp;
   </li>
   <li>
     Teaching material in Spanish by Leandro Vendramin:<br/>
@@ -81,6 +99,14 @@ toc: Documentation
     with contributions by Kenneth Monks and Ellen Ziliak.
     <br />&nbsp;
   </li>
+  <li>
+    The book <a href="https://www.cambridge.org/vi/academic/subjects/mathematics/algebra/representations-groups-computational-approach">"Representations of Groups: A Computational Approach"</a>
+    by Klaus Lux and Herbert Pahlings (Cambridge University Press, 2010) provides a number of computational exercises and examples using GAP.<br />&nbsp;
+  </li>  
+  <li>
+    The book <a href="https://link.springer.com/book/10.1007/978-1-4419-0160-6">"Numerical Semigroups"</a>
+    by J. C. Rosales and <a href="https://www.ugr.es/~pedro">P. A. García Sánchez</a> (Springer, 2009).<br />&nbsp;
+  </li> 
   <li>
     There are
     <a href="http://www.math.colostate.edu/~hulpke/CGT/cgtnotes2up.pdf">
@@ -197,8 +223,13 @@ toc: Documentation
 Other examples of use of GAP in teaching include: 
 <ul>
 <li>
-Theory of permutation groups by <a href="https://madeleinewhybrow.wordpress.com/">Madeleine Whybrow</a>
+<a href="https://github.com/MWhybrow92/Permutation-Groups">GAP exercises</a> for the
+Theory of permutation groups course by <a href="https://madeleinewhybrow.wordpress.com/">Madeleine Whybrow</a>
 (University of Primorska, Slovenia) since 2019.<br />&nbsp;
+</li>
+<li>
+Some applications of the course "Representations of finite groups" by Fernando Fantino
+(Universidad Nacional de Córdoba, Argentina) since 2019.<br />&nbsp;
 </li>
 <li>
 Two courses in Computational group theory
@@ -218,6 +249,16 @@ studied the use of GAP in courses on Group Theory and Coding Theory. The results
 and exercises for the courses Algebra, Algorithmic Algebra, and Commutative Algebra by 
 <a href="https://www.algebra.mathematik.uni-siegen.de/barakat/">Mohamed Barakat</a> (University of Siegen, Germany) 
 since 2017.<br />&nbsp;
+</li>
+<li>
+Use of GAP in the "Computational Techniques in Mathematics" course by
+Abdulhakeem Olayiwola (Sule Lamido University Kafin Hausa, Nigeria)
+since 2016.<br />&nbsp;
+</li>
+<li>
+Uygulamalı Cebir (Applied Algebra), Sembolik Hesaplama (Symbolic Computation)
+and GAP Programlama (GAP Programming) by <a href="http://fef.ogu.edu.tr/aodabas/">Alper Odabaş</a> (Osmangazi University, Turkey),
+starting from 2013.<br />&nbsp;
 </li>
 <li>
 Use of GAP at the Universidad de Almería (Spain) in the course Software en Matemáticas (since 2018);

--- a/Doc/Teaching/teaching.html
+++ b/Doc/Teaching/teaching.html
@@ -30,6 +30,67 @@ toc: Documentation
 </p>
 <ul>
   <li>
+    Teaching material in Spanish by <a href="https://www.ugr.es/~pedro">P. A. García Sánchez</a>:<br/>
+    - <a href="https://www.ugr.es/~pedro/gap/primeros-pasos.pdf">First steps</a><br/>
+    - <a href="https://www.ugr.es/~pedro/gap/practicas-GAP-AE.pdf">Algebra and discrete structures</a> (Computer Science, 2009-2010)<br/>
+    - <a href="https://www.ugr.es/~pedro/gap/practicas-GAP-MD.pdf">Discrete mathematics</a> (Computer Science, 2006-2009)<br/>
+    - <a href="https://www.ugr.es/~pedro/gap/practicas-GAP-AB.pdf">Basic algebra</a> (Mathematics, 2006-2010)<br/>
+    - <a href="https://github.com/pedritomelenas/Software-Matematicas-GAP/">GAP section of the course "Mathematical Software"</a> (Master in Mathematics, 2017-2020)
+    <br />&nbsp;
+  </li>
+    <li>
+    <a href="http://www.math.umn.edu/~webb/GAPfiles/">
+    GAP teaching materials and software packages</a> written by 
+    <a href="http://www.math.umn.edu/~webb">Peter&nbsp;Webb</a>,
+    University of Minnesota,
+    covering Permutation Groups, Matrices, Finite Fields and Matrix Groups, 
+    Groups given by Presentations, Stabilizer chains, Coset Enumeration (with updates in 2020).
+    <br />&nbsp;
+  </li>
+  <li>
+    Teaching material in Spanish by Leandro Vendramin:<br/>
+    - <a href="http://mate.dm.uba.ar/~lvendram/lectures/GAP.pdf">Una introducción al álgebra con GAP</a> (2016)<br/>&nbsp;
+  </li>
+  <li>
+    A lab manual
+    <a href="http://math.slu.edu/~rainbolt/manual8th.htm">
+    Abstract&nbsp;Algebra&nbsp;with&nbsp;GAP</a><br />
+    by {% include namelink.html name="Julianne Rainbolt" %} and
+    Joseph&nbsp;A.&nbsp;Gallian (latest version 2013)
+    containing a collection of exercises that use GAP
+    and are appropriate for a first course in abstract algebra.
+    This manual was originally developed to be used with Gallian's book   
+    <em>Contemporary Abstract Algebra</em>.
+    <br />&nbsp;
+  </li>
+  <li>
+    There are
+    <a href="http://www.math.colostate.edu/~hulpke/CGT/cgtnotes2up.pdf">
+    Notes for a graduate course in Computational Group Theory</a> (2008-2010)
+    by {% include namelink.html name="Alexander Hulpke" %}.
+    <br />&nbsp;
+  </li>
+  <li>  
+    <a href="http://www.maths.uwa.edu.au/~alice/KL">
+    Lectures&nbsp;and&nbsp;Workshops</a> on Groups, Applications, and
+    GAP by  
+    <a href="http://www.maths.uwa.edu.au/~alice">Alice&nbsp;Niemeyer</a>,
+    held in September  2004 at the University of Malaya at Kuala Lumpur. 
+    The course describes applications of GAP
+    to counting and randomised algorithms.
+    <br />&nbsp;
+  </li>
+  <li>
+    An online workshop
+    <a href="http://euler.slu.edu/GrantWebPages/PREP04AlgebraGap/GAPPREP.html">
+    Exploring&nbsp;Abstract&nbsp;Algebra&nbsp;Using&nbsp;Computer&nbsp;Software</a><br />
+    was held by {% include namelink.html name="Russell Blyth" %} and
+    {% include namelink.html name="Julianne Rainbolt" %}
+    in June 2004 under the auspices of the Mathematical Association of
+    America's Professional Enhancement Program.
+    <br />&nbsp;
+  </li>
+  <li>
     A course
     <a href="http://www.ux1.eiu.edu/~cfdmb/gap/index.html">
     Mathematics&nbsp;3530</a> - Abstract Algebra,<br />
@@ -49,46 +110,13 @@ toc: Documentation
     <br />&nbsp;
   </li>
   <li>
-    An online workshop
-    <a href="http://euler.slu.edu/GrantWebPages/PREP04AlgebraGap/GAPPREP.html">
-    Exploring&nbsp;Abstract&nbsp;Algebra&nbsp;Using&nbsp;Computer&nbsp;Software</a><br />
-    was held by {% include namelink.html name="Russell Blyth" %} and
-    {% include namelink.html name="Julianne Rainbolt" %}
-    in June 2004 under the auspices of the Mathematical Association of
-    America's Professional Enhancement Program.
+    <a href="https://alex-konovalov.github.io/ukrgap/Examples/Examples.htm">
+    Algebra&nbsp;and&nbsp;number&nbsp;theory&nbsp;with&nbsp;GAP</a>
+    (in Russian)<br/>
+    by {% include namelink.html name="Alexander Konovalov" %} (2002-2008).
     <br />&nbsp;
   </li>
-  <li>
-    A lab manual 
-    <a href="http://math.slu.edu/~rainbolt/manual8th.htm">
-    Abstract&nbsp;Algebra&nbsp;with&nbsp;GAP</a><br />
-    by {% include namelink.html name="Julianne Rainbolt" %} and 
-    Joseph&nbsp;A.&nbsp;Gallian
-    containing a collection of exercises that use GAP
-    and are appropriate for a first course in abstract algebra.
-    This manual was originally developed to be used with Gallian's book   
-    <em>Contemporary Abstract Algebra</em>).
-    <br />&nbsp;
-  </li>
-  <li>
-    <a href="http://www.math.umn.edu/~webb/GAPfiles/">
-    Eight&nbsp;GAP&nbsp;lessons</a> by 
-    <a href="http://www.math.umn.edu/~webb">Peter&nbsp;Webb</a>,
-    University of Minnesota,
-    covering Permutation Groups, Matrices, Finite Fields and Matrix Groups, 
-    Groups given by Presentations, Stabilizer chains, Coset Enumeration.
-    <br />&nbsp;
-  </li>
-  <li>  
-    <a href="http://www.maths.uwa.edu.au/~alice/KL">
-    Lectures&nbsp;and&nbsp;Workshops</a> on Groups, Applications, and
-    GAP by  
-    <a href="http://www.maths.uwa.edu.au/~alice">Alice&nbsp;Niemeyer</a>,
-    held in September  2004 at the University of Malaya at Kuala Lumpur. 
-    The course describes applications of GAP
-    to counting and randomised algorithms.
-    <br />&nbsp;
-  </li>
+<!--
   <li>
     <a href="http://www.win.tue.nl/~amc/ow/bachproj/BachelorProjectCIGIP.pdf">
     Graph&nbsp;Isomorphism&nbsp;Problem</a>
@@ -98,6 +126,7 @@ toc: Documentation
     functions to examine graphs.
     <br />&nbsp;
   </li>
+-->
 <!--
   <li>
     An introduction to using GAP to perform Polya counting with 
@@ -108,32 +137,6 @@ toc: Documentation
     <br />&nbsp;
   </li>
 -->
-  <li>
-    Information on usage of CommSemi and other semigroups functionality
-    in GAP can be found in "Tutorial - Computing with
-    semigroups in GAP" by
-    Isabel M. Araújo and
-    Andrew Solomon,
-    which is available 
-    <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.18.3578">here</a>.
-    <br />&nbsp;
-  </li>
-  <li>
-    Teaching material in French:<br/>
-    Calculs en théorie des groupes et introduction au langage GAP,<br/>
-    Journées  mathématiques  X-UPS  2000,  ``groupes  finis'', 71--94,<br/>
-    Éditions de l'école Polytechnique.
-    <a href="http://www.math.jussieu.fr/~jmichel/papiers/xups.dvi">dvi</a>.
-    by <a href="http://www.math.jussieu.fr/~jmichel">Jean&nbsp;Michel</a>.
-    <br />&nbsp;
-  </li>
-  <li>
-    <a href="https://alex-konovalov.github.io/ukrgap/Examples/Examples.htm">
-    Algebra&nbsp;and&nbsp;number&nbsp;theory&nbsp;with&nbsp;GAP</a>
-    (in Russian)<br/>
-    by {% include namelink.html name="Alexander Konovalov" %}.
-    <br />&nbsp;
-  </li>
   <li>
     Teaching material in Japanese:<br/>
     The home page of 
@@ -146,31 +149,30 @@ toc: Documentation
     <br />&nbsp;
   </li>
   <li>
+    Teaching material in French:<br/>
+    Calculs en théorie des groupes et introduction au langage GAP,<br/>
+    Journées  mathématiques  X-UPS  2000,  ``groupes  finis'', 71--94,<br/>
+    Éditions de l'école Polytechnique.
+    <a href="http://www.math.jussieu.fr/~jmichel/papiers/xups.dvi">dvi</a>.
+    by <a href="http://www.math.jussieu.fr/~jmichel">Jean&nbsp;Michel</a>.
+    <br />&nbsp;
+  </li>
+  <li>
+    Information on usage of CommSemi and other semigroups functionality
+    in GAP can be found in "Tutorial - Computing with
+    semigroups in GAP" by
+    Isabel M. Araújo and
+    Andrew Solomon,
+    which is available 
+    <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.18.3578">here</a>.
+    <br />&nbsp;
+  </li>  
+  <li>
     The package
     <a href="{{ site.baseurl }}/Packages/itc.html">ITC</a> can be used to demonstrate the
     working of some coset table methods. Examples are given in the
     <a href="{{ site.baseurl }}/Manuals/pkg/itc/htm/chapters.htm">ITC&nbsp;manual</a>.
     <br />&nbsp;
-  </li>
-  <li>
-    There are lecture notes
-    <a href="http://www.math.colostate.edu/~hulpke/CGT/cgtnotes2up.pdf">
-    Notes for a graduate course in Computational Group Theory</a> (Summer 2008)
-    by {% include namelink.html name="Alexander Hulpke" %}.
-    <br />&nbsp;
-  </li>
-  <li>
-    Teaching material in Spanish by <a href="https://www.ugr.es/~pedro">P. A. García Sánchez</a>:<br/>
-    - <a href="https://www.ugr.es/~pedro/gap/primeros-pasos.pdf">First steps</a><br/>
-    - <a href="https://www.ugr.es/~pedro/gap/practicas-GAP-AE.pdf">Algebra and discrete structures</a> (Computer Science, 2009-2010)<br/>
-    - <a href="https://www.ugr.es/~pedro/gap/practicas-GAP-MD.pdf">Discrete mathematics</a> (Computer Science, 2006-2009)<br/>
-    - <a href="https://www.ugr.es/~pedro/gap/practicas-GAP-AB.pdf">Basic algebra</a> (Mathematics, 2006-2010)<br/>
-    - <a href="https://github.com/pedritomelenas/Software-Matematicas-GAP/">GAP section of the course "Mathematical Software"</a> (Master in Mathematics, 2017-2020)
-    <br />&nbsp;
-  </li>
-  <li>
-    Teaching material in Spanish by Leandro Vendramin:<br/>
-    - <a href="http://mate.dm.uba.ar/~lvendram/lectures/GAP.pdf">Una introducción al álgebra con GAP</a><br/>
   </li>
 </ul>
 

--- a/Doc/Teaching/teaching.html
+++ b/Doc/Teaching/teaching.html
@@ -13,9 +13,11 @@ toc: Documentation
 <p>
   GAP has been used in lecture courses of various levels,
   both for providing examples and for creating teaching material, in
-  particular exercises. We recently conducted a survey on this topic,
+  particular exercises. In 2012, we conducted a survey on this topic,
   and its results are published on the
   <a href="http://education.lms.ac.uk/2012/03/gap-in-teaching/">LMS De Morgan Forum</a>.
+  We are currently conducting a new survey about the use of mathematical
+  software in education at <a href="https://bit.ly/mse-survey">https://bit.ly/mse-survey</a>.
 </p>
 <p>
   However, it is not always the case that

--- a/Doc/Teaching/teaching.html
+++ b/Doc/Teaching/teaching.html
@@ -47,9 +47,18 @@ toc: Documentation
     Groups given by Presentations, Stabilizer chains, Coset Enumeration (with updates in 2020).
     <br />&nbsp;
   </li>
+  <li> 
+    M. D'Anna, V. Micale and <a href="https://www.ugr.es/~pedro">P. A. García Sánchez</a> gave the course
+    <a href="http://www.scuolasuperiorecatania.it/it/semigruppi-numerici-e-applicazioni-0">"Semigruppi numerici e applicazioni"</a>
+    at the Scuola Superiore di Catania, during the academic year 2016-17, 
+    where GAP was used. They gave an introduction to NumericalSgps and GUAVA packages.
+    <a href="https://github.com/pedritomelenas/SSC-Semigroups">This repository</a> contains a 
+    <a href="https://pedritomelenas.github.io/SSC-Semigroups/Live/gap-numericalsgps-thebelab.html">live tutorial of NumericalSgps</a>
+    using <a href="https://github.com/executablebooks/thebe">Thebe</a>.<br/>&nbsp;
+  </li>
   <li>
     Teaching material in Spanish by Leandro Vendramin:<br/>
-    - <a href="http://mate.dm.uba.ar/~lvendram/lectures/GAP.pdf">Una introducción al álgebra con GAP</a> (2016)<br/>&nbsp;
+    - <a href="http://mate.dm.uba.ar/~lvendram/lectures/GAP.pdf">Una introducción al álgebra con GAP</a> (2016).<br/>&nbsp;
   </li>
   <li>
     A lab manual
@@ -61,6 +70,15 @@ toc: Documentation
     and are appropriate for a first course in abstract algebra.
     This manual was originally developed to be used with Gallian's book   
     <em>Contemporary Abstract Algebra</em>.
+    <br />&nbsp;
+  </li>
+  <li>
+    There is an introduction to using GAP with material appropriate
+    for an undergraduate abstract algebra course: 
+    <a href="https://www.math.colostate.edu/%7Ehulpke/CGT/howtogap.pdf">
+    Abstract Algebra in GAP</a> (2011)
+    by {% include namelink.html name="Alexander Hulpke" %},
+    with contributions by Kenneth Monks and Ellen Ziliak.
     <br />&nbsp;
   </li>
   <li>
@@ -176,3 +194,46 @@ toc: Documentation
   </li>
 </ul>
 
+Other examples of use of GAP in teaching include: 
+<ul>
+<li>
+Theory of permutation groups by <a href="https://madeleinewhybrow.wordpress.com/">Madeleine Whybrow</a>
+(University of Primorska, Slovenia) since 2019.<br />&nbsp;
+</li>
+<li>
+Two courses in Computational group theory
+(<a href="https://www3.monash.edu/pubs/2019handbooks/units/MTH4141.html">MTH4141</a> and
+<a href="https://www3.monash.edu/pubs/2019handbooks/units/MTH5141.html">MTH5141</a>) by
+<a href="http://users.monash.edu/~heikod/">Heiko Dietrich</a> (Monash University, Australia)<br />&nbsp;
+</li>
+<li>
+In a pedagogical research project in 2018, C. Alonso González, R. Guerrero Francés, M. A. Navarro Pérez, 
+V. Ortiz Sotomayor and X. Soler Escrivà, (Universitat d’Alacant and Universitat Politècnica de València, Spain) 
+studied the use of GAP in courses on Group Theory and Coding Theory. The results of the study where published
+<a href="https://rua.ua.es/dspace/bitstream/10045/101711/1/Memories-Xarxes-I3CE-2018-19-141.pdf">here</a>
+(see also an extended version included into the <a href="http://rua.ua.es/dspace/handle/10045/98732">whole volume</a>).<br />&nbsp;
+</li>
+<li>
+<a href="https://www.algebra.mathematik.uni-siegen.de/barakat/teaching/W19/PraktikumCA/">Computeralgebra Praktikum I & II (Mathematical programming exercises)<a>
+and exercises for the courses Algebra, Algorithmic Algebra, and Commutative Algebra by 
+<a href="https://www.algebra.mathematik.uni-siegen.de/barakat/">Mohamed Barakat</a> (University of Siegen, Germany) 
+since 2017.<br />&nbsp;
+</li>
+<li>
+Use of GAP at the Universidad de Almería (Spain) in the course Software en Matemáticas (since 2018);
+and also the GUAVA package for Coding Theory in the course
+<a href="http://cms.ual.es/UAL/ht/estudios/titulaciones/titulacion/asignaturas/asignatura/TITULACION4100?id=&idTit=4100&idAss=40007321&idCaracter=O">"Teoría de la Información y la Codificación"</a>
+in the degree of Computer Science (since 2012). GAP was also used in the course
+<a href="http://cms.ual.es/UAL/universidad/departamentos/matematicas/docencia/asignaturas/asignatura/index.htm?id=6250&idTit=4000&idAss=40002202&idCaracter=B">"Ampliación de Matemática Discreta"</a>
+during several years, mainly for polynomials over finite extensions of finite fields, between 2004 and 2011.<br />&nbsp;
+</li>
+<li>
+Grupos y Anillos (Groups and Rings), Códigos Correctores y Criptografía (Error Correcting Codes and Cryptography), Teoría de Números (Number Theory)
+by <a href="https://www.um.es/adelrio/">Ángel del Río</a> (Universidad de Murcia, Spain), starting circa 2010.<br />&nbsp;
+</li>
+<li>
+Number Theory and Applications; Semigroups, Automata and Languages (the package Automata);
+Algebraic Coding Theory (the package GUAVA); and other courses in algebra 
+by <a href="https://cmup.fc.up.pt/cmup/mdelgado/">Manuel Delgado</a> (University of Porto, Portugal), starting circa 2010.<br />&nbsp;
+</li>
+</ul>


### PR DESCRIPTION
Update GAP use in Teaching page:
- reorder to put most recent first
- add some materials collected at https://github.com/gap-system/GapWWW/issues/148
- add some more sources reported elsewhere