### PR TITLE
deps for cddInterface, curlInterface, ZeroMQInterface

### DIFF
--- a/Download/tools.html
+++ b/Download/tools.html
@@ -44,7 +44,7 @@ To install development tools on a Linux system, use your preferred package
 manager (e.g. apt-get or aptitude or Synaptic etc.). For example, on Ubuntu
 or Debian we suggest that you call
 <pre>
-  sudo apt-get install build-essential autoconf libtool libgmp-dev libreadline-dev zlib1g-dev
+  sudo apt-get install build-essential autoconf libtool libgmp-dev libreadline-dev zlib1g-dev libcdd libcurl4-openssl-dev libczmq-dev
 </pre>
 before calling <code>>configure</code> in the GAP root directory.
 </p>


### PR DESCRIPTION
As suggested by Bruce Ikenaga on the support list:
this is needed to build
cddInterface-2020-01.01,
curlInterface-2.1.1, and ZeroMQInterface-0.12