### PR TITLE
Fix link to HAPprime home page

### DIFF
--- a/Packages/packages.html
+++ b/Packages/packages.html
@@ -134,7 +134,7 @@ No longer redistributed with GAP or renamed:
      <a href="{{ site.baseurl }}/Packages/nconvex.html">NConvex</a>.</li>
   <li>Gpd - this package has been renamed to
      <a href="{{ site.baseurl }}/Packages/groupoids.html">groupoids</a>.</li>
-  <li><a href="{{ site.baseurl }}/Packages/happrime.html">HAPprime</a> - part of 
+  <li><a href="https://gap-packages.github.io/happrime">HAPprime</a> - part of 
      the code has been incorporated into the
      <a href="{{ site.baseurl }}/Packages/hap.html">HAP</a> package. 
      Its source code repository, containing the code of the 


### PR DESCRIPTION
This fixes one of the broken links reported at #214.