### PR TITLE
Create _data/release.yml file

### DIFF
--- a/Contacts/People/Council/council.html
+++ b/Contacts/People/Council/council.html
@@ -39,7 +39,7 @@ subtoc: People
   the page on <a href="{{ site.baseurl }}/Contacts/submit.html">submission&nbsp;procedures</a>.
 </p>
 <p>
-  The present ({{site.data.gap.relyear}}) members of the GAP Council are:
+  The present ({{site.data.release.year}}) members of the GAP Council are:
 </p>
 <ul>
   <li>

--- a/Contacts/cite.html
+++ b/Contacts/cite.html
@@ -12,12 +12,12 @@ toc: Contacts
 </p>
 <dl>
 <dt>
-[GAP{{site.data.gap.relyear}}]
+[GAP{{site.data.release.year}}]
 </dt>
 <dd>
   The GAP Group, GAP -- Groups, Algorithms,
-  and Programming, Version {{site.data.gap.relversion}}; 
-  {{site.data.gap.relyear}}.
+  and Programming, Version {{site.data.release.version}}; 
+  {{site.data.release.year}}.
   (https://www.gap-system.org)
 </dd>
 </dl>
@@ -53,8 +53,8 @@ href="{{ site.baseurl }}/Packages/packages.html">package overview</a> page.)
     key          = "GAP",
     organization = "The GAP~Group",
     title        = "{GAP -- Groups, Algorithms, and Programming,
-                    Version {{site.data.gap.relversion}}}",
-    year         = {{site.data.gap.relyear}},
+                    Version {{site.data.release.version}}}",
+    year         = {{site.data.release.year}},
     url          = "\url{https://www.gap-system.org}",
     }
 </pre>
@@ -68,8 +68,8 @@ href="{{ site.baseurl }}/Packages/packages.html">package overview</a> page.)
 <pre>
   \bibitem[GAP]{GAP4}
   The GAP~Group, \emph{GAP -- Groups, Algorithms, and Programming, 
-  Version {{site.data.gap.relversion}}}; 
-  {{site.data.gap.relyear}},
+  Version {{site.data.release.version}}}; 
+  {{site.data.release.year}},
   \url{https://www.gap-system.org}.
 </pre>
 

--- a/Doc/manuals.html
+++ b/Doc/manuals.html
@@ -8,7 +8,7 @@ toc: Documentation
 
 <p>
 Here are HTML and PDF versions of the manuals of the 
-GAP&nbsp;{{site.data.gap.relversion}} core system.
+GAP&nbsp;{{site.data.release.version}} core system.
 </p>
 <table class="par">
 <tr><th>Book name</th><th>

--- a/Download/copyright.html
+++ b/Download/copyright.html
@@ -8,7 +8,7 @@ toc: Installation
   GAP is
 </p>
 <pre>
-  Copyright (C) (1987--{{site.data.gap.relyear}}) by the GAP Group,
+  Copyright (C) (1987--{{site.data.release.year}}) by the GAP Group,
 
   incorporating the Copyright (C) 1999, 2000  by
         School of Mathematical and Computational Sciences,

--- a/Download/index.html
+++ b/Download/index.html
@@ -6,15 +6,15 @@ toc: Installation
 
 <p class="center">
 The current version is 
-<a href="{{ site.baseurl }}/Releases/{{site.data.gap.relversion}}.html">GAP&nbsp;{{site.data.gap.relversion}}</a> 
-released on {{site.data.gap.reldate}}.
+<a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">GAP&nbsp;{{site.data.release.version}}</a> 
+released on {{site.data.release.date}}.
 </p>
 
 <h4>Upgrading or New Installation?</h4>
 
 <p>
 If you have any version of GAP older than the
-<a href="{{ site.baseurl }}/Releases/{{site.data.gap.relversion}}.html">current version</a>,
+<a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">current version</a>,
 the only way to install a new version of GAP
 is a new installation.
 </p>
@@ -53,7 +53,7 @@ be interested to know about it.
     system is distributed under the terms of the GNU Public
     License (<a href="copyright.html">details</a> are given on a separate page),
     packages may have other licenses.
-The copyright (C) (1987--{{site.data.gap.relyear}}) for the core part of the 
+The copyright (C) (1987--{{site.data.release.year}}) for the core part of the 
 GAP distribution is by the GAP Group.
 The copyright of redistributed packages remains with their authors.
 </p>
@@ -69,7 +69,7 @@ GAP using the source distribution, perform the following steps:
 </p>
 
 <ul>
-<li>Choose your preferred archive format and <a href="{{ site.baseurl }}/Releases/{{site.data.gap.relversion}}.html">download</a> 
+<li>Choose your preferred archive format and <a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">download</a> 
 the corresponding archive.</li>
 <li>Unpack the archive.</li>
 <li>On UNIX, Linux or macOS: compile the GAP core system
@@ -94,7 +94,7 @@ your machine.</li>
 <p>
 Links to the latest archives in four <a href="formats.html">formats</a>
 (.tar.gz, .tar.bz2, .zip and -win.zip) and an .exe Windows installer
-can be found on the <a href="{{ site.baseurl }}/Releases/{{site.data.gap.relversion}}.html">Downloads</a> page.
+can be found on the <a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">Downloads</a> page.
 If you use Unix or macOS, you can use the .tar.gz, .tar.bz2 or .zip
 archives. If you use Windows, then we strongly recommend to use the .exe
 install, and use the -win.zip archives only when this is really necessary.
@@ -179,7 +179,7 @@ in this order:
 </p>
 <ul>
 <li>Look at the "If Things Go Wrong" section of the
-<a href="https://github.com/gap-system/gap/blob/master/INSTALL.md">GAP {{site.data.gap.relversion}} Installation Instructions</a>,
+<a href="https://github.com/gap-system/gap/blob/master/INSTALL.md">GAP {{site.data.release.version}} Installation Instructions</a>,
 it contains some additional remarks and troubleshooting advices.</li>
 <li>Tell us about your problem by writing an email to <a
 href="mailto:support@gap-system.org">support@gap-system.org</a>.</li>

--- a/Download/install.html
+++ b/Download/install.html
@@ -15,7 +15,7 @@ GAP using the source distribution, perform the following steps:
 </p>
 
 <ul>
-<li>Choose your preferred archive format and <a href="{{ site.baseurl }}/Releases/{{site.data.gap.relversion}}.html">download</a> 
+<li>Choose your preferred archive format and <a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">download</a> 
 the corresponding archive.</li>
 <li>Unpack the archive.</li>
 <li>On UNIX, Linux or macOS: compile the GAP core system

--- a/Download/upgrade.html
+++ b/Download/upgrade.html
@@ -6,7 +6,7 @@ toc: Installation
 
 <p>
 If you have any version of GAP older than the
-<a href="{{ site.baseurl }}/Releases/{{site.data.gap.relversion}}.html">most recent public release</a>,
+<a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">most recent public release</a>,
 the only way to install a new version of GAP
 is a <a href="index.html">new installation</a>.
 </p>

--- a/_data/gap.yml
+++ b/_data/gap.yml
@@ -1,22 +1,3 @@
-# The content of _data/gap.yml and lib/config must always be kept in sync
-# TODO: perhaps we can generate one from the other, and/or add a script
-# which verify the two match?
-
-#############################################################################
-##
-#V  The place where the GAP distribution may be accessed for download
-##
-gap3dist: 'https://files.gap-system.org/gap-3.4.4/'
-gap4dist: 'https://files.gap-system.org/gap4/'
-gap44dist: 'https://files.gap-system.org/gap44/'
-gap45dist: 'https://files.gap-system.org/gap45/'
-gap46dist: 'https://files.gap-system.org/gap46/'
-gap47dist: 'https://files.gap-system.org/gap47/'
-gap48dist: 'https://files.gap-system.org/gap48/'
-gap49dist: 'https://files.gap-system.org/gap-4.9/'
-gap410dist: 'https://files.gap-system.org/gap-4.10/'
-gap411dist: 'https://files.gap-system.org/gap-4.11/'
-
 #############################################################################
 ##
 #V  depositdir      The place where deposited g3 contributions are to be found
@@ -34,13 +15,16 @@ depositdir: 'https://files.gap-system.org/gap-3.4.4/deposit/'
 deposit4dir: 'https://files.gap-system.org/gap44/deposit/'
 
 #############################################################################
-#   When a new GAP release is published, update parameters below this line  #
-#############################################################################
-
-#############################################################################
 ##
-#V  current GAP4 version
+#V  The place where the GAP distribution may be accessed for download
 ##
-relversion: '4.11.0'
-reldate: '29 February 2020'
-relyear: '2020'
+gap3dist: 'https://files.gap-system.org/gap-3.4.4/'
+gap4dist: 'https://files.gap-system.org/gap4/'
+gap44dist: 'https://files.gap-system.org/gap44/'
+gap45dist: 'https://files.gap-system.org/gap45/'
+gap46dist: 'https://files.gap-system.org/gap46/'
+gap47dist: 'https://files.gap-system.org/gap47/'
+gap48dist: 'https://files.gap-system.org/gap48/'
+gap49dist: 'https://files.gap-system.org/gap-4.9/'
+gap410dist: 'https://files.gap-system.org/gap-4.10/'
+gap411dist: 'https://files.gap-system.org/gap-4.11/'

--- a/_data/release.yml
+++ b/_data/release.yml
@@ -1,0 +1,5 @@
+# Release details concerning the most recently released GAP version
+# This file is automatically updated as part of the GAP release process
+version: '4.11.0'
+date: '29 February 2020'
+year: '2020'

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@ The first public release of GAP 4.5 was made on June 15th 2012
 (see <a href="https://mail.gap-system.org/pipermail/forum/2012/003707.html">here</a>). <br /><br />
 -->
 The current version is 
-<a href="Releases/{{site.data.gap.relversion}}.html">GAP&nbsp;{{site.data.gap.relversion}}</a> 
-released on {{site.data.gap.reldate}}.
+<a href="Releases/{{site.data.release.version}}.html">GAP&nbsp;{{site.data.release.version}}</a> 
+released on {{site.data.release.date}}.
 </p>
 <br />
 
@@ -56,8 +56,8 @@ Software Engineering applied to Computer Algebra</i>.
   How to obtain GAP?
 </h3>
 <p>
-  The current release is GAP&nbsp;{{site.data.gap.relversion}}
-  and it can be obtained from our <a href="{{ site.baseurl }}/Releases/{{site.data.gap.relversion}}.html">downloads page</a>.
+  The current release is GAP&nbsp;{{site.data.release.version}}
+  and it can be obtained from our <a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">downloads page</a>.
   This website describes this release if not stated otherwise.
   Changes from earlier versions are described in the
   <a href="https://github.com/gap-system/gap/blob/master/CHANGES.md">Release&nbsp;history</a>.


### PR DESCRIPTION
I have broken out the GAP release version number, date, and year from `_data/gap.yml` into this separate file. This should make it very easy for a script to update this file as part of an automated release process.

I have also put the `gap411dist` etc variables in `_data/gap.yml` into the end of the file; these are the only remaining values in this file which will we should expect to be added to, so a script could easily append to this file to add a `gap412dist` variable, say.