### PR TITLE
Show links to upstream archives on package pages

### DIFF
--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -126,4 +126,16 @@ layout: start
 <a href="mailto:{{ page.support-email }}">{{ page.support-email }}</a>
 </dd>
 {% endif %}
+
+{% if page.downloads.size >= 1 %}
+<dt>Download</dt>
+<dd>
+{{ page.base-archive-name }} &nbsp;
+{% assign downloads = "" %}
+{% for download in page.downloads %}
+    {% capture downloads %}{{ downloads }}[<a href="{{ download.url }}">{{ download.name }}</a>]|{% endcapture %}
+{% endfor %}
+{{ downloads | split: "|" | join: "&nbsp;&nbsp;&nbsp;" }}
+</dd>
+{% endif %}
 </dl>


### PR DESCRIPTION
Since we are stopping creating and hosting individual package archives, it might be a good idea to link to the archives listed in the package's `PackageInfo.g`.

Resolves #230.