### PR TITLE
Manually update URLs for the Semigroups and DeepThought packages

### DIFF
--- a/_Packages/deepthought.html
+++ b/_Packages/deepthought.html
@@ -38,14 +38,14 @@ needed-pkgs:
 
 suggested-pkgs: 
 external: 
-www: https://duskydolphin.github.io/DeepThoughtPackage/
+www: https://gap-packages.github.io/DeepThought/
 readme: README.md
-packageinfo: https://duskydolphin.github.io/DeepThoughtPackage/PackageInfo.g
+packageinfo: https://gap-packages.github.io/DeepThought/PackageInfo.g
 github: 
 
 downloads:
     - name: .tar.gz
-      url: https://github.com/duskydolphin/DeepThoughtPackage/releases/download/v1.0.2/DeepThought-1.0.2.tar.gz
+      url: https://github.com/gap-packages/DeepThought/releases/download/v1.0.2/DeepThought-1.0.2.tar.gz
 
 base-archive-name: DeepThought-1.0.2
 abstract: |
@@ -56,8 +56,8 @@ communicated-by:
 accept-date: 
 source-repo:
     type: git
-    url: https://github.com/duskydolphin/DeepThoughtPackage
-issue-url: "https://github.com/duskydolphin/DeepThoughtPackage/issues"
+    url: https://github.com/gap-packages/DeepThought
+issue-url: "https://github.com/gap-packages/DeepThought/issues"
 
 support-email: "nina.wagner@math.uni-giessen.de"
 
@@ -72,7 +72,7 @@ citeas: |
              Version 1.0.2</i>
      (<span class='BibYear'>2018</span>)<br />
     (<span class='BibNote'>GAP package</span>),
-    <span class='BibHowpublished'><a href="https://duskydolphin.github.io/DeepThoughtPackage/">https://duskydolphin.github.io/DeepThoughtPackage/</a></span>.
+    <span class='BibHowpublished'><a href="https://gap-packages.github.io/DeepThought/">https://gap-packages.github.io/DeepThought/</a></span>.
     </p>
     
 
@@ -84,8 +84,8 @@ bibtex: |
       month =            {Sep},
       year =             {2018},
       note =             {GAP package},
-      howpublished =     {\href             {https://duskydolphin.github.io/DeepThoughtPackage/}            {\texttt{https://duskydolphin.github.io/}\discretionary
-                          {}{}{}\texttt{DeepThoughtPackage/}}},
+      howpublished =     {\href             {https://gap-packages.github.io/DeepThought/}            {\texttt{https://gap-packages.github.io/}\discretionary
+                          {}{}{}\texttt{DeepThought/}}},
       keywords =         {Deep Thought; finitely generated nilpotent groups; Hall polynomials},
       printedkey =       {WH18}
     }

--- a/_Packages/semigroups.html
+++ b/_Packages/semigroups.html
@@ -119,14 +119,14 @@ suggested-pkgs:
       url: "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc"
 
 external: 
-www: https://gap-packages.github.io/Semigroups
+www: https://semigroups.github.io/Semigroups
 readme: README.md
-packageinfo: https://gap-packages.github.io/Semigroups/PackageInfo.g
+packageinfo: https://semigroups.github.io/Semigroups/PackageInfo.g
 github: 
 
 downloads:
     - name: .tar.gz
-      url: https://github.com/gap-packages/Semigroups/releases/download/v3.4.0/semigroups-3.4.0.tar.gz
+      url: https://github.com/semigroups/Semigroups/releases/download/v3.4.0/semigroups-3.4.0.tar.gz
 
 base-archive-name: semigroups-3.4.0
 abstract: |
@@ -137,8 +137,8 @@ communicated-by:
 accept-date: 
 source-repo:
     type: git
-    url: https://github.com/gap-packages/Semigroups
-issue-url: "https://github.com/gap-packages/Semigroups/issues"
+    url: https://github.com/semigroups/Semigroups
+issue-url: "https://github.com/semigroups/Semigroups/issues"
 
 support-email: 
 doc-html: doc/chap0.html
@@ -152,7 +152,7 @@ citeas: |
              Version 3.4.0</i>
      (<span class='BibYear'>2020</span>)<br />
     (<span class='BibNote'>GAP package</span>),
-    <span class='BibHowpublished'><a href="https://gap-packages.github.io/Semigroups">https://gap-packages.github.io/Semigroups</a></span>.
+    <span class='BibHowpublished'><a href="https://gsemigroups.github.io/Semigroups">https://semigroups.github.io/Semigroups</a></span>.
     </p>
     
 
@@ -163,7 +163,7 @@ bibtex: |
       month =            {Aug},
       year =             {2020},
       note =             {GAP package},
-      howpublished =     {\href {https://gap-packages.github.io/Semigroups} {\texttt{https://gap-packages.github.io/}\discretionary {}{}{}\texttt{Semigroups}}},
+      howpublished =     {\href {https://semigroups.github.io/Semigroups} {\texttt{https://semigroups.github.io/}\discretionary {}{}{}\texttt{Semigroups}}},
       keywords =         {transformation  semigroups;  partial  permutations;  inverse  semigroups;  Green's  relations;  free inverse semigroup; partition monoid;
                           bipartitions; Rees matrix semigroups},
       printedkey =       {Mit20}


### PR DESCRIPTION
Although this isn't an ideal or permanent solution, I've had several reports about the broken links to the Semigroups website, so I'd like to get it fixed for now.

See #234 for thoughts on how to handle this situation better.