### PR TITLE
Link to 64-bit .exe for GAP 4.11.1

### DIFF
--- a/_Releases/4.11.1.html
+++ b/_Releases/4.11.1.html
@@ -195,10 +195,36 @@ provide the latest GAP release.
 <h2>Windows</h2>
 
 <p>
-There is no Windows installer with precompiled binaries for GAP available at this time.
-We hope to make one available in the future.
+For users of Windows 10, we strongly recommend using GAP via the
+<a href="https://docs.microsoft.com/en-us/windows/wsl/about">Windows Subsystem
+  for Linux</a>.
 </p>
 
+<p>
+Otherwise, we recommend the use of the following <code>.exe</code> installer, which contains 64-bit binaries for GAP
+(compiled with the support of GMP and readline libraries) and for selected
+GAP packages, and provides the standard installation procedure.
+</p>
+
+<p>
+Note that the path to the GAP directory should not contain spaces. For example,
+you may install it in <code>C:\gap-{{page.version}}</code> (default), <code>D:\gap-{{page.version}}</code> or
+<code>C:\Math\GAP\gap-{{page.version}}</code>, but you must not install it in a directory named like
+<code>C:\Program files\gap-{{page.version}}</code> or <code>C:\Users\alice\My Documents\gap-{{page.version}}</code> etc.
+</p>
+
+<table>
+ <colgroup>
+  <col width="30%">
+  <col width="20%">
+  <col width="50%">
+ </colgroup>
+<tr>
+  <td align="left"><a href="https://github.com/gap-system/gap/releases/download/v4.11.1/gap-4.11.1.exe">gap-4.11.1.exe</a></td>
+  <td align="left">638 MB</td>
+  <td align="left">sha256: cf5df64588514426dd0c9a46c058b9e4f7bf7c9be7f6ccd566a3029a7e4c2b03</td>
+</tr>
+</table>
 
 <h2>Packages included in this release</h2>
 


### PR DESCRIPTION
I have mostly copied the text from the Windows bit of the previous release, i.e. https://www.gap-system.org/Releases/4.11.0.html. In addition, I have made the recommended Windows route to be with the Windows Subsystem for Linux - I hope this is uncontroversial.

But I do not know whether the details that it contains are still accurate (about GMP, readline, spaces in filenames, etc). @alex-konovalov please can you check that the details are accurate?