### PR TITLE
Adds a paper on the arxiv citing GAP.

### DIFF
--- a/Doc/Bib/GapCite.notyet
+++ b/Doc/Bib/GapCite.notyet
@@ -293,3 +293,10 @@ pages = "213--232",
 journal = "Portugaliae Mathematica",
 number = "3",
 }
+
+@article{JGroups2021,
+  author = "Bernhardt, Dominik and Boykett, Tim and Devillers, Alice and Flake, Johannes and Glasby, S. P.}",
+  title = "Groups G satisfying a functional equation f(xk) = xf(x) for some k in G",
+  note = "Preprint, {\url{https://arxiv.org/abs/2105.09117}}",
+  year = "2021",
+}

--- a/Doc/Bib/GapCite.notyet
+++ b/Doc/Bib/GapCite.notyet
@@ -296,7 +296,7 @@ number = "3",
 
 @article{JGroups2021,
   author = "Bernhardt, Dominik and Boykett, Tim and Devillers, Alice and Flake, Johannes and Glasby, S. P.}",
-  title = "Groups G satisfying a functional equation f(xk) = xf(x) for some k in G",
+  title = "Groups $G$ satisfying a functional equation $f(xk) = xf(x)$ for some $k \in G$",
   note = "Preprint, {\url{https://arxiv.org/abs/2105.09117}}",
   year = "2021",
 }


### PR DESCRIPTION
Adds [a paper](https://arxiv.org/abs/2105.09117) citing GAP to the references of not yet published papers citing GAP.