### PR TITLE
Replace Travis with GitHub Actions for testing whether the site builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    name: Build the Jekyll site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo gem install jekyll
+      - run: jekyll build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-
-before_script:
-  - gem install jekyll
-
-script:
-  - jekyll build


### PR DESCRIPTION
This is currently quite slow (3½ minutes), but since we don't run it very often I don't think we should spend time speeding it up just yet.

This doesn't actually do anything with the built site, but it at least lets us see if a pull request or push is going to actually break the website such that it doesn't build.

This runs on pushes, on PRs, and can be manually dispatched.

This resolves the original issue raised in #236, but not the bigger suggestion of @fingolfin; I'll either make a new issue for that, or rename #236.