### PR TITLE
Fix broken links to package manuals

### DIFF
--- a/Doc/manuals.html
+++ b/Doc/manuals.html
@@ -38,13 +38,14 @@ available.
 
 {% assign pkgs = site.data.package-infos[site.data.release.version-safe] | sort %}
 {% for pkg in pkgs %}
+  {% assign dir = pkg[1].InstallationPath | split: "-" | slice: 0 %}
   <tr>
     <td>
-      <a href="../Manuals/{{ pkg[1].InstallationPath }}/{{ pkg[1].PackageDoc[0].HTMLStart }}">
+      <a href="../Manuals/{{ dir }}/{{ pkg[1].PackageDoc[0].HTMLStart }}">
         {{ pkg[1].PackageName }}</a>
     </td>
     <td>
-      [<a href="../Manuals/{{ pkg[1].InstallationPath }}/{{ pkg[1].PackageDoc[0].PDFFile }}">PDF</a>]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+      [<a href="../Manuals/{{ dir }}/{{ pkg[1].PackageDoc[0].PDFFile }}">PDF</a>]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     </td>
     <td>
       {{ pkg[1].Subtitle }}


### PR DESCRIPTION
The links to manuals would use the `InstallationPath` value of a package for its directory name, but this sometimes includes the version number. However, the `extract_manuals.py` script now strips any version number from the directory name when extracting the package manuals for uploading to the website.

So we now need to remove any version numbers when making the links too. I do this by stripped anything after (and include) a hyphen, but this is risky if a package ever properly contains a hyphen as part of its name. Would it be safe to just use `dir = pkg[1].PackageName`?

Fixes #252.

Thanks to @veni-vidi-code for the report.