### PR TITLE
Mention required tools in install instructions

### DIFF
--- a/Download/index.html
+++ b/Download/index.html
@@ -69,6 +69,7 @@ GAP using the source distribution, perform the following steps:
 </p>
 
 <ul>
+<li>Verify that <a href="tools.html">all required tools</a> are installed.</li>
 <li>Choose your preferred archive format and <a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">download</a> 
 the corresponding archive.</li>
 <li>Unpack the archive.</li>
@@ -210,4 +211,3 @@ as you would cite an article or book (see recommended
 on mathematical and programming questions concerning GAP. 
 Announcements of bugfixes, new versions and new packages are also sent to that list.
 </p>
-

--- a/Download/install.html
+++ b/Download/install.html
@@ -15,6 +15,7 @@ GAP using the source distribution, perform the following steps:
 </p>
 
 <ul>
+<li>Verify that <a href="tools.html">all required tools</a> are installed.</li>
 <li>Choose your preferred archive format and <a href="{{ site.baseurl }}/Releases/{{site.data.release.version}}.html">download</a> 
 the corresponding archive.</li>
 <li>Unpack the archive.</li>


### PR DESCRIPTION
This does not deal with the bigger questions such as:
- why do we provide these instructions in two places?
- should we provide them in this form at all, or shouldn't we just link to `INSTALL.md` (resp. integrate `INSTALL.md` more tightly into the website
