### PR TITLE
Fix a link on `Contacts/submit.html`

### DIFF
--- a/Contacts/submit.html
+++ b/Contacts/submit.html
@@ -144,7 +144,7 @@ toc: Contacts
   or about any other GAP-related matters of which the Council
   should be aware. We provide a list with the names and current mail and
   email addresses of the
-  <a href="{{ site.baseurl }}/Contacts/People/Council/members.html">members</a> of the
+  <a href="{{ site.baseurl }}/Contacts/People/Council/council.html">members</a> of the
   GAP Council.
 </p>
 


### PR DESCRIPTION
The linked page does not exist. But I have corrected the link to point to the page that does have the appropriate information.