### PR TITLE
fixed a few inconsistencies

### DIFF
--- a/Packages/Authors/authors.html
+++ b/Packages/Authors/authors.html
@@ -136,10 +136,12 @@ with <code>../../..</code> as 5th argument.)
 Alternatively, you can use the "traditional" GAP4 manual format, i.e. TeX 
 with some additional macros, which, provided you use it carefully, can be
 processed directly by GAP as on-line help, processed 
-by TeX for printing and processed by a perl script provided in the 
-"tools" archive to make HTML. This format is partly
+by TeX for printing and processed by a perl script
+to make HTML. This format is partly
 documented in the document "The gapmacro.tex Manual Format" 
-which is included in the ``tools'' archive contained in the
+which is included in the
+<code>doc</code> directory of the GAP installation,
+and the perl script is included in the
 <code>etc</code> directory of the GAP installation.
 (Here, also copy your package in the standard location 
 <code>pkg/&lt;pkgname&gt;</code> when building the HTML 

--- a/Packages/Authors/authors.html
+++ b/Packages/Authors/authors.html
@@ -18,27 +18,37 @@ package authors have done.)
 
 <h3>Getting Started Writing a Package</h3>
 <p>
-The GAP  documentation contains a 
-{% include ref.html label="Using and Developing GAP Packages" text="chapter" %} 
-on using GAP packages.
-All advice on developing GAP packages has been consolidated in 
-the <a href="{{ site.baseurl }}/Packages/example.html">Example</a> package. 
+The GAP Reference Manual contains a
+{% include ref.html label="Using and Developing GAP Packages" text="chapter on using and developing GAP packages" %},
+which describes the rules and conventions for the structure of a GAP package,
+and the GAP functions that deal with package administration.
 </p>
 
 <p>
 The interface between GAP and a GAP
 package consists of two or three files <code>PackageInfo.g</code>, 
-<code>init.g</code> and <code>read.g</code>. The first of these contains
-meta information on a package for loading and (possibly) distribution. 
-Probably the easiest way to create it to use the
-<a href="http://gap-packages.github.io/example/PackageInfo.g"><code>PackageInfo.g</code></a>
-file from the <a href="{{ site.baseurl }}/Packages/example.html">Example</a> package, which
-has detailed comments on each entry. Alternatively, you can use the tool called
+<code>init.g</code>, and perhaps <code>read.g</code>. The first of these contains
+meta information on the package for loading and (possibly) distribution.
+There are different ways to create a new package.
+</p>
+
+<ul>
+<li>
+You can use the tool called
 <a href="https://github.com/gap-system/PackageMaker">PackageMaker</a>, which
 asks several questions about the intended package, and then creates a basic
 package accordingly to the provided information. For details, please refer to
 <a href="https://github.com/gap-system/PackageMaker">its documentation</a>.
-</p>
+</li>
+<li>
+Or you can copy an existing package and adjust its content by hand.
+In particular a new <code>PackageInfo.g</code> file can be created easily
+from a working one, for example from the
+<a href="http://gap-packages.github.io/example/PackageInfo.g"><code>PackageInfo.g</code></a>
+file from the <a href="{{ site.baseurl }}/Packages/example.html">Example</a> package, which
+has detailed comments on each entry.
+</li>
+</ul>
 
 <p>
 As the number of packages and library modules in GAP grows, it is important to
@@ -47,7 +57,7 @@ same global  variable names in inconsistent ways.  See the page
 <a href="{{ site.baseurl }}/Packages/Authors/variablenames.html">Use&nbsp;of&nbsp;Global&nbsp;Variable&nbsp;Names</a> 
 as well as the subsection 
 {% include ref.html label="Functions and Variables and Choices of Their Names" text="Functions&nbsp;and&nbsp;Variables&nbsp;and&nbsp;Choices&nbsp;of&nbsp;Their&nbsp;Names" %}
-of the manual of the <a href="{{ site.baseurl }}/Packages/example.html">Example</a> package
+of the GAP Reference Manual
 for advice how to avoid such 'name clashes'.
 </p>
 
@@ -116,7 +126,7 @@ Firstly, and the way we recommend, you can use the
 <a href="{{ site.baseurl }}/Packages/gapdoc.html">GAPDoc</a> package 
 which allows you to write documentation in a concise and well-specified
 XML-like language. This documentation can then be processed using GAPDoc to
-produce on-line help, printed manuals and web pages.
+produce on-line help, printed manuals, and web pages.
 (To get machine independent cross-links in your documentation, copy
 your package in the standard location <code>pkg/&lt;pkgname&gt;</code>
 and use {% include coderef.html book="GAPDoc" label="MakeGAPDocDoc" %}
@@ -139,7 +149,7 @@ version of your manual to get cross-links right.)
 Finally, you can develop your own solution, complying with the interfaces
 described in chapter 
 {% include ref.html label="Interface to the GAP Help System" text="Interface to the GAP Help System" %}
-of the programmers reference manual. There are
+of the GAP Reference Manual. There are
 certain technical issues with this approach, and we would advise you to
 contact us if you are considering it.
 </p>
@@ -171,8 +181,7 @@ Further advice could be found, for example, at <a href="http://choosealicense.co
 <h4>Setup for Distribution</h4>
 <p>
 What you have to do to take part in the update mechanism is
-also explained in the template  <a
-href="PackageInfo.g"><code>PackageInfo.g</code></a> file mentioned above:
+also explained in the <code>PackageInfo.g</code> file mentioned above:
 </p>
 <ul>
 <li>Set up a Web page for your package. There are no conditions how this
@@ -226,23 +235,19 @@ file of the DESIGN package of Leonard Soicher.
 </li>
 </ul>
 
-<h3>Validating <code>PackageInfo.g</code> File</h3>
+<h3>Validating a <code>PackageInfo.g</code> File</h3>
 
 <p>
-GAP packages must  contain a file
-<code>PackageInfo.g</code> in which meta-information is collected:
+Each GAP package must contain a file
+<code>PackageInfo.g</code> in which meta information is collected, such as
 package name, version, authors/maintainers with contact addresses, location
 of download archive(s), infos on provided manuals, ... 
-This is used for loading a package into GAP and for a possible
-redistribution of a package via the GAP website.
+This is used for loading the package into GAP and for a possible
+redistribution of the package via the GAP website.
 </p> 
-<p>See 
-<a href="http://gap-packages.github.io/example/PackageInfo.g">this template file</a>
-for more details and if you want to create such a file for your package.
-</p>
 <p>
-A basic check for such a file is provided by the command 
-<code>ValidatePackageInfo(filename);</code> from within GAP.
+A basic check for such a file from within GAP is provided by the function
+{% include coderef.html label="ValidatePackageInfo" %}.
 </p>
 
 <h3>Adjusting Packages for next major releases of GAP</h3>
@@ -254,7 +259,7 @@ Packages which worked with GAP version &lt;4.4 needed a few adjustments, and
 hints how to achieve this were collected on <a href="pkgauthorhints.html">this page</a>.
 To make further use of these new features, we refer to these
 {% include ref.html label="Package release checklists" text="Checklists" %}
-from the <a href="{{ site.baseurl }}/Packages/example.html">Example</a> package.
+in the GAP Reference Manual.
 </p>
 
 


### PR DESCRIPTION
I have tried to fix wrong statements.

~Afterwards, one thing is still wrong on the page:~
> ~This format is partly documented in the document "The gapmacro.tex Manual Format" which is included in the ``tools'' archive contained in the etc directory of the GAP installation.~

~I find files concerning `gapmacro.tex` in the `doc` directory. Is this the official location for them?~