### PR TITLE
Add an imprint and privacy policy to comply with GPDR

### DIFF
--- a/_layouts/core.html
+++ b/_layouts/core.html
@@ -28,18 +28,6 @@
 
 {{ content }}
 
-<tr>
-
-<td class="footer" colspan="2">
-
-<hr />
-
-<a href="mailto:support@gap-system.org">The GAP Group</a>
-<!-- TODO: Last updated: TIMESTAMP -->
-
-</td>
-</tr>
-
 </table>
 </body>
 </html>

--- a/_layouts/start.html
+++ b/_layouts/start.html
@@ -23,12 +23,9 @@ layout: core
 <a href="{{ site.baseurl }}/Faq/faq.html">        FAQ</a>&nbsp;
 <a href="{{ site.baseurl }}/Gap3/gap3.html">       GAP&nbsp;3</a>&nbsp;
 </td>
-
 </tr>
 
 <tr>
-
-
 <td class="leftsidebar">
     <h4><a href="https://github.com/gap-system">Find us on GitHub</a></h4>
     <h3>Navigation Tree</h3>
@@ -89,8 +86,14 @@ layout: core
         {% endfor %}
     {% endif %}
     </table>
-    <div style="margin-top: 4ex;">
-    <a href="https://github.com/gap-system/GapWWW/edit/master/{{ page.path }}">Edit this page</a>
+    <div style="padding-top: 2em; padding-bottom: 2em;">
+    <hr>
+    </div>
+    <div>
+    <a href="https://github.com/gap-system/GapWWW/edit/master/{{ page.path }}">Edit this page</a><br>
+    <a href="mailto:support@gap-system.org">Contact</a><br>
+    <a href="https://www.uni-kl.de/en/imprint/">Imprint</a><br>
+    <a href="https://www.uni-kl.de/en/privacy/">Privacy Policy</a><br>
     </div>
 </td>
 


### PR DESCRIPTION
We just link to the imprint and privacy policy of TU Kaiserslautern for
now. Since those refer explicit to a "Contact" link, also make
one clearly visible next to the other two new links in the navbar.

In exchange, remove the footer email link "The GAP Group", it seems
redundant.

Here is a preview of how the changed navbar looks like. It's not great (clearly we need a full redesign), but IMHO "good enough".

<img width="197" alt="Screenshot 2022-08-11 at 15 35 31" src="https://user-images.githubusercontent.com/241512/184145830-3fe2d716-3a76-42c9-8dd5-3e5d59e8a6f4.png">

Resolves #273