### PR TITLE
GAP 4.12.0 contains perfect groups up to 2*10^6

### DIFF
--- a/Datalib/perfect.html
+++ b/Datalib/perfect.html
@@ -10,7 +10,7 @@ toc: Data Libraries
 
 <p>
   This library is part of the core GAP system.
-  It contains almost all perfect groups of size up to 10^6.
+  It contains all perfect groups of size up to $2\cdot 10^6$.
 </p>
 
 <h3>


### PR DESCRIPTION
To be merged once 4.12.0 is out.