### PR TITLE
Remove mentions of directories with spaces for GAP 4.12

### DIFF
--- a/_layouts/releases.html
+++ b/_layouts/releases.html
@@ -97,8 +97,8 @@ available. For almost all users, 64-bit GAP is by far the better choice.
 Please note that the provision of 32-bit Windows installers is likely to be
 dropped from GAP releases in the near future.
 </p>
-{% endif %}
-
+{% else %}
+<!-- Only for GAP before 4.12 -->
 <p>
 Note that the path to the GAP directory should not contain spaces. For example,
 you may install GAP in <code>C:\gap-{{page.version}}</code> (default),
@@ -107,6 +107,8 @@ you may install GAP in <code>C:\gap-{{page.version}}</code> (default),
 directory named like <code>C:\Program files\gap-{{page.version}}</code> or
 <code>C:\Users\alice\My Documents\gap-{{page.version}}</code> etc.
 </p>
+{% endif %}
+
 
 <table>
  <colgroup>


### PR DESCRIPTION
There is no need to worry about spaces in GAP 4.12.

I haven't been able to build this to test it (sorry!) as my computer is being stupid.