### PR TITLE
Update deprecated term "OS X" to "macOS"

### DIFF
--- a/_layouts/releases.html
+++ b/_layouts/releases.html
@@ -33,7 +33,7 @@ see <a href="https://github.com/gap-system/gap/blob/master/CHANGES.md#{{anchor}}
 
 
 {% if unix_assets.size > 0 %}
-<h2>Linux and OS X</h2>
+<h2>Linux and macOS</h2>
 
 <p>
 Download one of the <code>gap-{{page.version}}.*</code> archives below, unpack


### PR DESCRIPTION
Per discussion on Slack.