### PR TITLE
Change description of rsync distribution

### DIFF
--- a/Download/alternatives.html
+++ b/Download/alternatives.html
@@ -38,7 +38,7 @@ If you use Homebrew, you can install GAP using the
 </p>
 
 <h3>
-  GAP Rsync (f0r Linux)
+  GAP Rsync (for Linux)
 </h3>
 <p>
 {% include namelink.html name="Frank Lübeck" %} offers a

--- a/Download/alternatives.html
+++ b/Download/alternatives.html
@@ -38,6 +38,16 @@ If you use Homebrew, you can install GAP using the
 </p>
 
 <h3>
+  GAP Rsync (f0r Linux)
+</h3>
+<p>
+{% include namelink.html name="Frank Lübeck" %} offers a
+<a href="https://www.math.rwth-aachen.de/~Frank.Luebeck/GAPrsync/">Linux
+binary distribution</a> via remote syncronization with a reference
+installation which includes all packages and some optimisations.
+</p>
+
+<h3>
   Docker
 </h3>
 <p>
@@ -141,14 +151,5 @@ tell exactly which dependencies were missing. The last GAP release provided
 by BOB was GAP 4.7.9.
 </p>
 
-<h3>
-  GAP Rsync
-</h3>
-<p>
-{% include namelink.html name="Frank Lübeck" %} has been offering a
-<a href="http://www.math.rwth-aachen.de/~Frank.Luebeck/gap/rsync">Linux
-binary distribution</a> via remote syncronization with a reference
-installation which includes all packages and some optimisations.
-The last GAP release provided by this service was GAP 4.7.6.
-</p>
+
 


### PR DESCRIPTION
Since GAP 4.11 the rsync distribution of GAP was restarted (with a different technology because before we could not update from 4.7.6 for technical reasons). Is is now upgraded to GAP 4.12.0.