### PR TITLE
Update "Undeposited Implementations for GAP" page

### DIFF
--- a/Packages/undep.html
+++ b/Packages/undep.html
@@ -41,21 +41,6 @@ deterministic and the standard probabilistic approach.
 
 <li>
 <p> 
-<a href="http://cage.ugent.be/~jdebeule/">Jan De Beule</a>,
-<a href="http://cage.ugent.be/~pg/">Patrick Govaerts</a>, and 
-<a href="http://cage.ugent.be/~ls/">Leo Storme</a>:
-<b>The GAP4 package 
-<a href="http://cage.ugent.be/~jdebeule/pg/">pg</a></b>
-<br/>
-Topic: Implements algorithms for finite projective geometry. Provides 
-functions for projective spaces, functions dealing with subspaces, 
-collineations and the collineation group, and quadrics and hermitian 
-varieties. Converts a collineation group into a permutation group.
-</p>
-</li>
-
-<li>
-<p> 
 Carmen Cedillo,
 <a href="http://xamanek.izt.uam.mx/rene">Rene MacKinney-Romero</a>,
 <a href="http://xamanek.izt.uam.mx/map">Miguel Angel Pizaña</a>,
@@ -70,36 +55,6 @@ in the GAP distribution since at the moment it can not be used
 together with Digraphs and GRAPE packages.
 </p>
 </li>
-
-<li>
-<p> 
-Serena Cicalo and 
-<a href="http://www.science.unitn.it/~degraaf">Willem de Graaf</a>:
-<b>The GAP4 package 
-<a href="http://www.science.unitn.it/~degraaf/liering.html">LieRing</a></b>
-<br/>
-The GAP4 package for constructing and working with Lie rings. 
-The main topics of interest are: finitely presented Lie rings, the Lazard 
-correspondence, and <i>n</i>-Engel Lie rings.
-</p>
-</li>
-
-<li>
-<p> 
-<a href="http://www.math.vt.edu/people/rcone">Randy Cone</a>,
-<a href="http://www.math.vt.edu/people/green">Edward Green</a> and
-<a href="http://www.math.ntnu.no/~oyvinso/">Oeyvind Solberg</a>:
-<b>The GAP4 package 
-<a href="http://sourceforge.net/projects/quiverspathalg/">QPA</a></b>
-<br/>
-The QPA package provides data structures and algorithms for doing computations 
-with finite dimensional quotients of path algebras, and finitely generated 
-modules over such algebras. The current version of the QPA package has data 
-structures for quivers, quotients of path algebras, and modules, homomorphisms 
-and complexes of modules over quotients of path algebras.
-</p>
-</li>
-
 
 <li>
 <p>
@@ -130,7 +85,7 @@ of the Smith normal form.
 The <b>biogap</b> has two goals: providing algebraic tools for 
 modelling bacterial genomes and also creating publication quality 
 diagrams.
-Available at <a href="https://bitbucket.org/dersu/biogap/">biogap</a>.
+Available at <a href="https://github.com/gap-packages/biogap/">biogap</a>.
 </p>
 </li>
 
@@ -145,14 +100,14 @@ Hierarchical composition and decomposition of finite permutation groups
 and transformation semigroups: substructures of wreath product with 
 explicitly represented dependency structure. It is distributed under the
 GPLv3 license.
-Available at <a href="http://sgpdec.sourceforge.net/">SpgDec</a>.
+Available at <a href="https://github.com/gap-packages/sgpdec/">SpgDec</a>.
 </p>
 </li>
 
 <li>
 <p>
-<a href="http://www.math.rwth-aachen.de/~Frank.Luebeck/">Frank Luebeck</a>:
-<b>The GAP package <a href="http://www.math.rwth-aachen.de/~Frank.Luebeck/gap/FUtil/">FUtil</a></b><br/>
+<a href="https://www.math.rwth-aachen.de/~Frank.Luebeck/">Frank Luebeck</a>:
+<b>The GAP package <a href="https://www.math.rwth-aachen.de/~Frank.Luebeck/gap/FUtil/">FUtil</a></b><br/>
 The package provides various tools for use with GAP.
 Currently, there are two topics covered by this package:
 <ul>
@@ -457,51 +412,3 @@ Undeposited implementations for GAP&nbsp;3
 </ul>
 
 (For GAP&nbsp;3 deposited contributions, see <a href="../Gap3/Contrib3/contrib.html">here</a>).
-
-<center>
-<h2>
-External programs and interface routines
-</h2>
-</center>
-
-Some optional interfaces to GAP are listed below for the user's information.
-However, they are not officially supported by the GAP support team and may not work on all
-operating systems.
-
-<ul>
-
-<li>
-<b>GGAP</b>: For a GUI version of GAP, check out GGAP written by Yevgen Muntyan:
- <a href="http://ggap.sourceforge.net/">http://ggap.sourceforge.net/</a>.
-Thanks to Alexander Hulpke, there is an installer for GAP 4.4.12 and GGAP (Windows and OS X) at
-<a href="http://www.math.colostate.edu/~hulpke/CGT/education.html">http://www.math.colostate.edu/~hulpke/CGT/education.html</a>.
-</li>
-
-<li>
-<b>Sage</b>: The <a href="http://sagemath.org/">Sage</a> <a href="http://sagenb.org/">notebook</a> interface provides a GUI for GAP. 
-If you are running the notebook remotely (e.g., on sagenb.org) then select GAP from the drop-down menu near the top of the browser's page for a worksheet.
-If you are running the sage notebook locally, type
-
-<pre>
-sage: notebook("gap",open_viewer=True,system="gap")
-</pre>
-
-This does three things:
-
-<ol>
-<li>
-puts the banner "gap" on your worksheet (it does not save or name your worksheet "gap" though),
-</li>
-<li>
-opens firefox (or a new tab if firefox is already running) and starts a sage notebook interface running there,
-</li>
-<li>
-makes every input box "gap command only". 
-</li>
-</ol>
-For more information on the Sage notebook or the Sage interface with GAP, please see the 
-<a href="http://doc.sagemath.org/html/en/reference/">Sage Reference Manual</a>.
-</li>
-
-</ul>
-


### PR DESCRIPTION
- remove references to GGAP and 4.4.12 installers
- remove a gratuitous reference to Sage (of course it is fine for us to
  point out to people that one can use Sage to access Sage, but not
  *there*)
- remove references to various packages that are now deposited (LieRing,
  QPA) or were superseded by a deposited GAP package (pg -> fining)
- update a bunch of links
