### PR TITLE
Remove broken happrime link

### DIFF
--- a/Packages/packages.html
+++ b/Packages/packages.html
@@ -118,7 +118,7 @@ No longer redistributed with GAP or renamed:
      <a href="{{ site.baseurl }}/Packages/nconvex.html">NConvex</a>.</li>
   <li>Gpd - this package has been renamed to
      <a href="{{ site.baseurl }}/Packages/groupoids.html">groupoids</a>.</li>
-  <li><a href="{{ site.baseurl }}/Packages/happrime.html">HAPprime</a> - part of 
+  <li>HAPprime - part of 
      the code has been incorporated into the
      <a href="{{ site.baseurl }}/Packages/hap.html">HAP</a> package. 
      Its source code repository, containing the code of the 


### PR DESCRIPTION
We don't want to replace this with another link, the existing link to the (archive) repository is enough.

Resolves #214. Closes #215