### PR TITLE
Disable reference to outdated docker containers

### DIFF
--- a/Download/alternatives.html
+++ b/Download/alternatives.html
@@ -46,7 +46,7 @@ If you use Homebrew, you can install GAP using the
 binary distribution</a> via remote syncronization with a reference
 installation which includes all packages and some optimisations.
 </p>
-
+<!--
 <h3>
   Docker
 </h3>
@@ -72,7 +72,7 @@ to start GAP. Note that you may have to run it with sudo,
 particularly if you are on Ubuntu. Further instructions could be found
 <a href="https://hub.docker.com/r/gapsystem/gap-docker/">here</a>.
 </p>
-  
+-->
 <h3>
   Gap.app (macOS only)
 </h3>


### PR DESCRIPTION
Can be re-enabled if/when these are up-to-date again