### PR TITLE
Tweak a pointer to the support email address

### DIFF
--- a/Contacts/contacts.md
+++ b/Contacts/contacts.md
@@ -10,7 +10,8 @@ A separate page
 [People]({{ site.baseurl }}/Contacts/People/people.html)
 acknowledges the help given to the GAP project in different ways by many
 colleagues. All of these are refered to as the **"GAP Group"**. To
-contact the GAP Group by email, please use the address
+contact the GAP Group by email regarding matters concerning the
+GAP computer algebra system, please use the address
 <support@gap-system.org>.
 
 The GAP Group is most interested in close contact to the users of GAP.


### PR DESCRIPTION
Moderators of the support mailing list are seeing a LOT of emails coming
from people who really want to contact the support of the GAP clothing
company. They are finding our email address via a Google search for 'how
do I email gap', which prompts Google to show a 'snippet' text from our
website -- namely the text modified by this patch. With the revision, I
hope that either Google will stop showing this snippet, or that at least
some people will realize that this is the wrong GAP.
