### PR TITLE
Centralize package status into a single file

### DIFF
--- a/_data/package-infos/4-11-0.json
+++ b/_data/package-infos/4-11-0.json
@@ -82,7 +82,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/HeLP",
     "IssueTrackerURL": "https://github.com/gap-packages/HeLP/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/HeLP"
@@ -182,7 +181,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/anupq/",
     "IssueTrackerURL": "https://github.com/gap-packages/anupq/issues",
     "BannerString": "---------------------------------------------------------------------------\nLoading    ANUPQ (ANU p-Quotient) 3.2.1\nGAP code by  Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)\n           Werner Nickel (http://www.mathematik.tu-darmstadt.de/~nickel/)\n           [uses ANU pq binary (C code program) version: 1.9]\nC code by  Eamonn O'Brien (https://www.math.auckland.ac.nz/~obrien)\nCo-maintained by Max Horn <max.horn@uni-siegen.de>\n\n            For help, type: ?ANUPQ\n---------------------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/anupq"
@@ -195,9 +193,7 @@
     "README_URL": "https://gap-packages.github.io/anupq/README",
     "PackageInfoURL": "https://gap-packages.github.io/anupq/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">ANUPQ</span> package provides an interactive    interface to the p-quotient, p-group generation and standard presentation    algorithms of the ANU pq C program.",
-    "Autoload": false,
-    "CommunicatedBy": "Charles Wright (Eugene)",
-    "AcceptDate": "04/2002"
+    "Autoload": false
   },
   "autpgrp": {
     "Version": "1.10.2",
@@ -265,7 +261,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/autpgrp/",
     "IssueTrackerURL": "https://github.com/gap-packages/autpgrp/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/autpgrp"
@@ -277,9 +272,7 @@
     "ArchiveURL": "https://github.com/gap-packages/autpgrp/releases/download/v1.10.2/autpgrp-1.10.2",
     "README_URL": "https://gap-packages.github.io/autpgrp/README",
     "PackageInfoURL": "https://gap-packages.github.io/autpgrp/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">AutPGrp</span> package introduces a new function to compute the automorphism group of a finite $p$-group. The underlying algorithm is a refinement of the methods described in O'Brien (1995). In particular, this implementation is more efficient in both time and space requirements and hence has a wider range of applications than the ANUPQ method. Our package is written in GAP code and it makes use of a number of methods from the GAP library such as the MeatAxe for matrix groups and permutation group functions. We have compared our method to the others available in GAP. Our package usually out-performs all but the method designed for finite abelian groups. We note that our method uses the small groups library in certain cases and hence our algorithm is more effective if the small groups library is installed.",
-    "CommunicatedBy": "Derek F. Holt (Warwick)",
-    "AcceptDate": "09/2000"
+    "AbstractHTML": "The <span class=\"pkgname\">AutPGrp</span> package introduces a new function to compute the automorphism group of a finite $p$-group. The underlying algorithm is a refinement of the methods described in O'Brien (1995). In particular, this implementation is more efficient in both time and space requirements and hence has a wider range of applications than the ANUPQ method. Our package is written in GAP code and it makes use of a number of methods from the GAP library such as the MeatAxe for matrix groups and permutation group functions. We have compared our method to the others available in GAP. Our package usually out-performs all but the method designed for finite abelian groups. We note that our method uses the small groups library in certain cases and hence our algorithm is more effective if the small groups library is installed."
   },
   "format": {
     "Version": "1.4.3",
@@ -343,7 +336,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/format/",
     "IssueTrackerURL": "https://github.com/gap-packages/format/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/format"
@@ -355,9 +347,7 @@
     "ArchiveURL": "https://github.com/gap-packages/format/releases/download/v1.4.3/format-1.4.3",
     "README_URL": "https://gap-packages.github.io/format/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/format/PackageInfo.g",
-    "AbstractHTML": "This package provides functions for computing with formations of finite solvable groups.",
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
-    "AcceptDate": "12/2000"
+    "AbstractHTML": "This package provides functions for computing with formations of finite solvable groups."
   },
   "4ti2interface": {
     "Version": "2019.09.02",
@@ -409,7 +399,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/4ti2Interface/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -486,7 +475,6 @@
     ],
     "PackageWWWHome": "https://github.com/rhysje00/agt",
     "IssueTrackerURL": "https://github.com/rhysje00/agt/issues",
-    "Status": "other",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/rhysje00/agt"
@@ -593,7 +581,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/AutoDoc",
     "IssueTrackerURL": "https://github.com/gap-packages/AutoDoc/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/AutoDoc"
@@ -685,7 +672,6 @@
       }
     ],
     "PackageWWWHome": "http://www.math.rwth-aachen.de/~Browse",
-    "Status": "deposited",
     "Subtitle": "browsing applications and ncurses interface",
     "ArchiveFormats": ".tar.bz2",
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Browse/Browse-1.8.8",
@@ -770,7 +756,6 @@
       }
     ],
     "PackageWWWHome": "http://homalg-project.github.io/CAP_project/CAP/",
-    "Status": "deposited",
     "Subtitle": "Categories, Algorithms, Programming",
     "License": "GPL-2.0-or-later",
     "ArchiveFormats": ".tar.gz .zip",
@@ -833,7 +818,6 @@
       "doc/manual.dvi",
       "carat.tgz"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/caratinterface"
@@ -846,9 +830,7 @@
     "README_URL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CaratInterface/README.CaratInterface",
     "PackageInfoURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CaratInterface/PackageInfo.g",
     "AbstractHTML": "This package provides <span class=\"pkgname\">GAP</span> interface routines to some of the stand-alone programs of <a href=\"https://lbfm-rwth.github.io/carat\">CARAT</a>, a package for the computation with crystallographic groups. CARAT is to a large extent complementary to the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">Cryst</span>. In particular, it provides routines for the computation of normalizers and conjugators of finite unimodular groups in GL(n,Z), and routines for the computation of Bravais groups, which are all missing in <span class=\"pkgname\">Cryst</span>. A catalog of Bravais groups up to dimension 6 is also provided.",
-    "SupportEmail": "gaehler@math.uni-bielefeld.de",
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
-    "AcceptDate": "02/2000"
+    "SupportEmail": "gaehler@math.uni-bielefeld.de"
   },
   "cddinterface": {
     "Version": "2020.01.01",
@@ -899,7 +881,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/CddInterface",
     "IssueTrackerURL": "https://github.com/homalg-project/CddInterface/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/CddInterface"
@@ -975,7 +956,6 @@
     ],
     "PackageWWWHome": "https://duskydolphin.github.io/DeepThoughtPackage/",
     "IssueTrackerURL": "https://github.com/duskydolphin/DeepThoughtPackage/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/duskydolphin/DeepThoughtPackage"
@@ -1039,7 +1019,6 @@
       }
     ],
     "PackageWWWHome": "http://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/frankluebeck/EDIM"
@@ -1052,9 +1031,7 @@
     "README_URL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/README",
     "PackageInfoURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/PackageInfo.g",
     "AbstractHTML": "This package provides  a collection of functions for computing the Smith normal form of integer matrices and some related utilities.",
-    "Autoload": false,
-    "CommunicatedBy": "Mike Atkinson (St Andrews)",
-    "AcceptDate": "08/1999"
+    "Autoload": false
   },
   "example": {
     "Version": "4.2.1",
@@ -1121,7 +1098,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/example",
     "IssueTrackerURL": "https://github.com/gap-packages/example/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/example"
@@ -1236,7 +1212,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/ExamplesForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -1307,7 +1282,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/FPLSA",
     "IssueTrackerURL": "https://github.com/gap-packages/FPLSA/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/FPLSA"
@@ -1319,9 +1293,7 @@
     "ArchiveURL": "https://github.com/gap-packages/FPLSA/releases/download/v1.2.4/FPLSA-1.2.4",
     "README_URL": "https://gap-packages.github.io/FPLSA/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/FPLSA/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">FPLSA</span> package uses    the authors' C program (version 4.0) that implements    a Lie Todd-Coxeter method for converting    finitely presented Lie algebras into isomorphic    structure constant algebras.    This is called via the GAP function IsomorphismSCTableAlgebra.",
-    "CommunicatedBy": "Steve Linton (St Andrews)",
-    "AcceptDate": "07/1999"
+    "AbstractHTML": "The <span class=\"pkgname\">FPLSA</span> package uses    the authors' C program (version 4.0) that implements    a Lie Todd-Coxeter method for converting    finitely presented Lie algebras into isomorphic    structure constant algebras.    This is called via the GAP function IsomorphismSCTableAlgebra."
   },
   "factint": {
     "Version": "1.6.3",
@@ -1388,7 +1360,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/FactInt",
     "IssueTrackerURL": "https://github.com/gap-packages/FactInt/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/FactInt"
@@ -1407,9 +1378,7 @@
         "Abstract": "<#Include SYSTEM \"abstract.xml\">",
         "Acknowledgements": "\n      I would like to thank Bettina Eick and Steve Linton for their support\n      and many interesting discussions.\n      "
       }
-    },
-    "CommunicatedBy": "Mike Atkinson (St. Andrews)",
-    "AcceptDate": "07/1999"
+    }
   },
   "gapdoc": {
     "Version": "1.6.3",
@@ -1488,7 +1457,6 @@
     ],
     "PackageWWWHome": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc",
     "IssueTrackerURL": "https://github.com/frankluebeck/GAPDoc/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/frankluebeck/GAPDoc"
@@ -1499,9 +1467,7 @@
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.3",
     "README_URL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/README.txt",
     "PackageInfoURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/PackageInfo.g",
-    "AbstractHTML": "This package contains a definition of a structure for <span class='pkgname'>GAP</span> (package) documentation, based on XML. It also contains  conversion programs for producing text-, PDF- or HTML-versions of such documents, with hyperlinks if possible.",
-    "CommunicatedBy": "Steve Linton (St Andrews)",
-    "AcceptDate": "10/2006"
+    "AbstractHTML": "This package contains a definition of a structure for <span class='pkgname'>GAP</span> (package) documentation, based on XML. It also contains  conversion programs for producing text-, PDF- or HTML-versions of such documents, with hyperlinks if possible."
   },
   "gauss": {
     "Version": "2019.09.02",
@@ -1574,7 +1540,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/Gauss/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -1656,7 +1621,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/GaussForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -1731,7 +1695,6 @@
       }
     ],
     "PackageWWWHome": "http://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/",
-    "Status": "deposited",
     "Subtitle": "Implementations of generalized morphisms for the CAP project",
     "License": "GPL-2.0-or-later",
     "ArchiveFormats": ".tar.gz .zip",
@@ -1874,7 +1837,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/GradedModules/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -2011,7 +1973,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/GradedRingForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -2152,7 +2113,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/HomalgToCAS/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -2267,7 +2227,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/IO_ForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -2337,7 +2296,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/intpic",
     "IssueTrackerURL": "https://github.com/gap-packages/intpic/issues",
     "BannerString": "----------------------------------------------------------------\nLoading  IntPic 0.2.4 (drawing integers)\nby Manuel Delgado (http://www.fc.up.pt/cmup/mdelgado/)\nFor help, type: ?IntPic;\n----------------------------------------------------------------\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/intpic"
@@ -2440,7 +2398,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/JupyterKernel/",
     "IssueTrackerURL": "https://github.com/gap-packages/JupyterKernel/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/JupyterKernel"
@@ -2523,7 +2480,6 @@
       }
     ],
     "PackageWWWHome": "http://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/",
-    "Status": "deposited",
     "Subtitle": "Category of Matrices over a Field for CAP",
     "License": "GPL-2.0-or-later",
     "ArchiveFormats": ".tar.gz .zip",
@@ -2617,7 +2573,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -2706,7 +2661,6 @@
     ],
     "PackageWWWHome": "https://MWhybrow92.github.io/MajoranaAlgebras/",
     "IssueTrackerURL": "https://github.com/MWhybrow92/MajoranaAlgebras/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/MWhybrow92/MajoranaAlgebras"
@@ -2787,7 +2741,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/MapClass",
     "IssueTrackerURL": "https://github.com/gap-packages/MapClass/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/MapClass"
@@ -2799,9 +2752,7 @@
     "README_URL": "https://gap-packages.github.io/MapClass/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/MapClass/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">MapClass</span> package calculates the    mapping class group orbits for a given finite group.",
-    "Autoload": false,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "11/2011"
+    "Autoload": false
   },
   "matricesforhomalg": {
     "Version": "2020.01.02",
@@ -2897,7 +2848,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/MatricesForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -2980,7 +2930,6 @@
       }
     ],
     "PackageWWWHome": "http://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/",
-    "Status": "deposited",
     "Subtitle": "Category R-pres for CAP",
     "License": "GPL-2.0-or-later",
     "ArchiveFormats": ".tar.gz .zip",
@@ -3110,7 +3059,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/Modules/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -3203,7 +3151,6 @@
       }
     ],
     "PackageWWWHome": "http://homalg-project.github.io/CAP_project/MonoidalCategories/",
-    "Status": "deposited",
     "Subtitle": "Monoidal and monoidal (co)closed categories",
     "TestFile": "tst/testall.g",
     "License": "GPL-2.0-or-later",
@@ -3296,7 +3243,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/NConvex",
     "IssueTrackerURL": "https://github.com/homalg-project/NConvex/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/NConvex"
@@ -3404,7 +3350,6 @@
     "PackageWWWHome": "https://pjastr.github.io/NoCK",
     "IssueTrackerURL": "https://github.com/pjastr/NoCK/issues",
     "BannerString": "----------------------------------------------------------------\nNoCK Package 1.4\nby Maciej Boche\u0144ski, Piotr Jastrz\u0119bski, Anna Szczepkowska, Aleksy Tralle, Artur Woike.\n----------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/pjastr/NoCK"
@@ -3416,9 +3361,7 @@
     "README_URL": "https://pjastr.github.io/NoCK/README.md",
     "PackageInfoURL": "https://pjastr.github.io/NoCK/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">NoCK</span> package    is used for computing Tolzanos's obstruction    for compact Clifford-Klein forms",
-    "SupportEmail": "piojas@matman.uwm.edu.pl",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "07/2019"
+    "SupportEmail": "piojas@matman.uwm.edu.pl"
   },
   "normalizinterface": {
     "Version": "1.1.0",
@@ -3486,7 +3429,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/NormalizInterface",
     "IssueTrackerURL": "https://github.com/gap-packages/NormalizInterface/issues",
     "BannerFunction": null,
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/NormalizInterface"
@@ -3673,7 +3615,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/numericalsgps",
     "IssueTrackerURL": "https://github.com/gap-packages/numericalsgps/issues",
     "BannerString": "----------------------------------------------------------------\nLoading  NumericalSgps 1.2.1\nFor help, type: ?NumericalSgps: \nTo gain profit from other packages, please refer to chapter\n'External Packages' in the manual, or type: ?NumSgpsUse \n----------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/numericalsgps"
@@ -3685,9 +3626,7 @@
     "ArchiveURL": "https://github.com/gap-packages/numericalsgps/releases/download/v1.2.1/NumericalSgps-1.2.1",
     "README_URL": "https://gap-packages.github.io/numericalsgps/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/numericalsgps/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">NumericalSgps</span> package, is a package to compute with numerical semigroups.",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "05/2015"
+    "AbstractHTML": "The <span class=\"pkgname\">NumericalSgps</span> package, is a package to compute with numerical semigroups."
   },
   "openmath": {
     "Version": "11.5.0",
@@ -3765,7 +3704,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/openmath",
     "IssueTrackerURL": "https://github.com/gap-packages/openmath/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/openmath"
@@ -3778,9 +3716,7 @@
     "README_URL": "https://gap-packages.github.io/openmath/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/openmath/PackageInfo.g",
     "AbstractHTML": "This package provides an <a href=\"http://www.openmath.org/\">OpenMath</a> phrasebook for <span class=\"pkgname\">GAP</span>. This package allows <span class=\"pkgname\">GAP</span> users to import and export mathematical objects encoded in OpenMath, for the purpose of exchanging them with other applications that are OpenMath enabled.",
-    "Autoload": false,
-    "CommunicatedBy": "David Joyner (Annapolis)",
-    "AcceptDate": "08/2010"
+    "Autoload": false
   },
   "packagemanager": {
     "Version": "1.0",
@@ -3830,7 +3766,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/PackageManager/",
     "IssueTrackerURL": "https://github.com/gap-packages/PackageManager/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/PackageManager"
@@ -3922,7 +3857,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/PatternClass/",
     "IssueTrackerURL": "https://github.com/gap-packages/PatternClass/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/PatternClass"
@@ -4001,7 +3935,6 @@
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/PolymakeInterface/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
     "BannerString": "----------------------------------------------------------------\nLoading  PolymakeInterface 2019.09.02\nby Thomas Baechler\n   Sebastian Gutsche (https://sebasguts.github.io)\n----------------------------------------------------------------\n---------polymake Header:---------------------------------------\nWelcome to polymake\nCopyright (c) 1997-2012\nEwgenij Gawrilow, Michael Joswig (TU Darmstadt)\nhttp://www.polymake.org\n----------------------------------------------------------------\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -4085,7 +4018,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/RepnDecomp",
     "IssueTrackerURL": "https://github.com/gap-packages/RepnDecomp/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/RepnDecomp"
@@ -4259,7 +4191,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/RingsForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -4344,7 +4275,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/SCO/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -4431,7 +4361,6 @@
     "BinaryFiles": [
       "demo/maple2gap.mw"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/scscp"
@@ -4444,9 +4373,7 @@
     "README_URL": "https://gap-packages.github.io/scscp/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/scscp/PackageInfo.g",
     "AbstractHTML": "This package implements the <a href=\"https://www.openmath.org/standard/scscp/\">Symbolic Computation Software Composability Protocol</a> for the GAP system.",
-    "Autoload": false,
-    "CommunicatedBy": "David Joyner (Annapolis)",
-    "AcceptDate": "08/2010"
+    "Autoload": false
   },
   "sgpviz": {
     "Version": "0.999.4",
@@ -4504,7 +4431,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/sgpviz",
     "IssueTrackerURL": "https://github.com/gap-packages/sgpviz/issues",
     "BannerString": "----------------------------------------------------------------\nLoading  SgpViz 0.999.4(semigroup visualization)\nFor help, type: ?SgpViz: \n----------------------------------------------------------------\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/sgpviz"
@@ -4589,7 +4515,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/smallgrp/",
     "IssueTrackerURL": "https://github.com/gap-packages/SmallGrp/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/SmallGrp"
@@ -4656,7 +4581,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/SymbCompCC/",
     "IssueTrackerURL": "https://github.com/gap-packages/SymbCompCC/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/SymbCompCC"
@@ -4668,9 +4592,7 @@
     "ArchiveURL": "https://github.com/gap-packages/SymbCompCC/releases/download/v1.3.1/SymbCompCC-1.3.1",
     "README_URL": "https://gap-packages.github.io/SymbCompCC/README",
     "PackageInfoURL": "https://gap-packages.github.io/SymbCompCC/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">SymbCompCC</span> package computes with parametrised presentations for finite p-groups of fixed coclass.",
-    "CommunicatedBy": "Mike Newman (Canberra, Australia)",
-    "AcceptDate": "11/2011"
+    "AbstractHTML": "The <span class=\"pkgname\">SymbCompCC</span> package computes with parametrised presentations for finite p-groups of fixed coclass."
   },
   "thelma": {
     "Version": "1.02",
@@ -4732,7 +4654,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/Thelma",
     "IssueTrackerURL": "https://github.com/gap-packages/Thelma/issues",
     "BannerString": "----------------------------------------------------------------\nLoading  Thelma 1.02, a package for threshold logic\nFor help, type: ?Thelma: \n----------------------------------------------------------------\n",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/Thelma"
@@ -4821,7 +4742,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/ToolsForHomalg/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -4887,7 +4807,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/toric",
     "IssueTrackerURL": "https://github.com/gap-packages/toric/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/toric"
@@ -4906,9 +4825,7 @@
         "Copyright": "&copyright; 2004-2017 David Joyner.",
         "Acknowledgements": "\nThe code for the <Package>toric</Package> package was written during the\nsummer of 2002. \nIt was put into &GAP; package format in the summer of 2004.\n<P/>\n    <Package>toric</Package> is free software; you can redistribute it and/or modify\n    it under the terms of the MIT License.\n<P/>\n    <Package>toric</Package> is distributed in the hope that it will be useful,\n    but WITHOUT ANY WARRANTY; without even the implied warranty of\n    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n    MIT License for more details.\n<P/>\n\n<P/>This documentation was prepared with the \n<Package>GAPDoc</Package> package of Frank L\u00fcbeck and Max Neunh\u00f6ffer. \nMoreover, a bug in toric 1.8 was fixed with the help of Max Horn, and this\ndocumentation was modified accordingly. Finally, I thank Olexandr Konovalov\nand Max Horn for transferring this package to the new Git repository.\n"
       }
-    },
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
-    "AcceptDate": "10/2005"
+    }
   },
   "toricvarieties": {
     "Version": "2019.12.05",
@@ -4995,7 +4912,6 @@
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/ToricVarieties/",
     "IssueTrackerURL": "https://github.com/homalg-project/homalg_project/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
@@ -5118,7 +5034,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/xmod/",
     "IssueTrackerURL": "https://github.com/gap-packages/xmod/issues",
     "BannerString": "Loading XMod 2.77 (methods for crossed modules and cat1-groups)\nby Chris Wensley (http://pages.bangor.ac.uk/~mas023/),\n with contributions from:\n    Murat Alp (muratalp@nigde.edu.tr),\n    Alper Odabas (aodabas@ogu.edu.tr),\nand Enver Uslu.\n-----------------------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmod"
@@ -5139,9 +5054,7 @@
         "Abstract": "The &XMod; package provides functions for computation with\n<List>\n  <Item>\n  finite crossed modules of groups and cat1-groups, \n  and morphisms of these structures; \n  </Item>\n  <Item>\n  finite pre-crossed modules, pre-cat1-groups,   and their Peiffer quotients;\n  </Item>\n  <Item>\n  isoclinism classes of groups and crossed modules; \n  </Item>\n  <Item>\n  derivations of crossed modules and sections of cat1-groups; \n  </Item>\n  <Item>\n  crossed squares and their morphisms,   including the actor crossed square of a crossed module; \n  </Item>\n  <Item>\n  crossed modules of finite groupoids (experimental version). \n  </Item>\n</List>\n<P/>\n&XMod; was originally implemented in 1996 using the &GAP;3 language, when the second author was studying for a Ph.D. <Cite Key='A1'/> in Bangor.\n<P/>\nIn April 2002 the first and third parts were converted to &GAP;4, the pre-structures were added, and version 2.001 was released. \nThe final two parts, covering derivations, sections and actors, were included in the January 2004 release 2.002 for &GAP; 4.4.\n<P/>\nIn October 2015 functions for computing isoclinism classes of crossed modules, written by Alper Odaba&#x15f; and Enver Uslu, were added.\nThese are contained in Chapter <Ref Chap='chap-isclnc' />, and are described in detail in the paper <Cite Key='IOU1' />.\n<P/>\nBug reports, suggestions and comments are, of course, welcome. Please submit an issue at <URL>https://github.com/gap-packages/xmod/issues/</URL> or send an email to the first author at <Email>c.d.wensley@bangor.ac.uk</Email>. \n<P/>\n",
         "Acknowledgements": "This documentation was prepared using the &GAPDoc; <Cite Key='GAPDoc'/> and &AutoDoc; <Cite Key='AutoDoc'/> packages.<P/>\nThe procedure used to produce new releases uses the package <Package>GitHubPagesForGAP</Package> <Cite Key='GitHubPagesForGAP' /> and the package <Package>ReleaseTools</Package>.<P/>"
       }
-    },
-    "CommunicatedBy": "Derek Holt (Warwick)",
-    "AcceptDate": "12/1996"
+    }
   },
   "xmodalg": {
     "Version": "1.17",
@@ -5205,7 +5118,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/xmodalg/",
     "IssueTrackerURL": "https://github.com/gap-packages/xmodalg/issues",
     "BannerString": "-----------------------------------------------------------------------------\nLoading XModAlg 1.17 (30/08/2018) for GAP 4.9 \nMethods for crossed modules of commutative algebras and cat1-algebras\nby Zekeriya Arvasi (zarvasi@ogu.edu.tr) and Alper Odabas (aodabas@ogu.edu.tr).\n-----------------------------------------------------------------------------\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmodalg"
@@ -5225,9 +5137,7 @@
         "Abstract": "The &XModAlg; package provides functions for computation with crossed modules of commutative algebras and cat<M>^{1}</M>-algebras.<P/>\nBug reports, suggestions and comments are, of course, welcome. Please submit an issue on GitHub at <URL>http://github.com/gap-packages/xmodalg/issues/</URL> or contact the second author at <Email>aodabas@ogu.edu.tr</Email>. \n<P/>\n",
         "Acknowledgements": "This documentation was prepared with the &GAPDoc; <Cite Key='GAPDoc'/> and &AutoDoc; <Cite Key='AutoDoc'/> packages.<P/>\nThe procedure used to produce new releases uses the package <Package>GitHubPagesForGAP</Package> <Cite Key='GitHubPagesForGAP' /> and the package <Package>ReleaseTools</Package>.<P/>\nBoth authors are very grateful to Chris Wensley (<URL>http://pages.bangor.ac.uk/~mas023/</URL>) for helpful suggestions.<P/>\nThis work was partially supported by T&#220;B&#304;TAK (The Scientific and Technical Research Council of Turkey), project number 107T542.<P/>"
       }
-    },
-    "CommunicatedBy": "",
-    "AcceptDate": ""
+    }
   },
   "yangbaxter": {
     "Version": "0.9.0",
@@ -5286,7 +5196,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/YangBaxter",
     "IssueTrackerURL": "https://github.com/gap-packages/YangBaxter/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/YangBaxter"
@@ -5366,7 +5275,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/ZeroMQInterface/",
     "IssueTrackerURL": "https://github.com/gap-packages/ZeroMQInterface/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/ZeroMQInterface"
@@ -5479,7 +5387,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/ace",
     "IssueTrackerURL": "https://github.com/gap-packages/ace/issues",
     "BannerString": "---------------------------------------------------------------------------\nLoading    ACE (Advanced Coset Enumerator) 5.3\nGAP code by Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)\n       Alexander Hulpke (https://www.math.colostate.edu/~hulpke)\n           [uses ACE binary (C code program) version: 3.001]\nC code by  George Havas (http://staff.itee.uq.edu.au/havas)\n           Colin Ramsay <cram@itee.uq.edu.au>\nCo-maintainer: Max Horn <max.horn@uni-siegen.de>\n\n                 For help, type: ?ACE\n---------------------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/ace"
@@ -5491,9 +5398,7 @@
     "ArchiveURL": "https://github.com/gap-packages/ace/releases/download/v5.3/ace-5.3",
     "README_URL": "https://gap-packages.github.io/ace/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/ace/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">ACE</span> package provides both an    interactive and non-interactive interface with the Todd-Coxeter coset   enumeration functions of the ACE (Advanced Coset Enumerator) C program.",
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
-    "AcceptDate": "04/2001"
+    "AbstractHTML": "The <span class=\"pkgname\">ACE</span> package provides both an    interactive and non-interactive interface with the Todd-Coxeter coset   enumeration functions of the ACE (Advanced Coset Enumerator) C program."
   },
   "aclib": {
     "Version": "1.3.2",
@@ -5563,7 +5468,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/aclib/",
     "IssueTrackerURL": "https://github.com/gap-packages/aclib/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/aclib"
@@ -5575,9 +5479,7 @@
     "ArchiveURL": "https://github.com/gap-packages/aclib/releases/download/v1.3.2/aclib-1.3.2",
     "README_URL": "https://gap-packages.github.io/aclib/README",
     "PackageInfoURL": "https://gap-packages.github.io/aclib/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">AClib</span> package contains a library of almost crystallographic groups and a some algorithms to compute with these groups. A group is called almost crystallographic if it is finitely generated nilpotent-by-finite and has no non-trivial finite normal subgroups. Further, an almost crystallographic group is called almost Bieberbach if it is torsion-free. The almost crystallographic groups of Hirsch length 3 and a part of the almost cyrstallographic groups of Hirsch length 4 have been classified by Dekimpe. This classification includes all almost Bieberbach groups of Hirsch lengths 3 or 4. The AClib package gives access to this classification; that is, the package contains this library of groups in a computationally useful form. The groups in this library are available in two different representations. First, each of the groups of Hirsch length 3 or 4 has a rational matrix representation of dimension 4 or 5, respectively, and such representations are available in this package. Secondly, all the groups in this libraray are (infinite) polycyclic groups and the package also incorporates polycyclic presentations for them. The polycyclic presentations can be used to compute with the given groups using the methods of the Polycyclic package.",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
-    "AcceptDate": "02/2001"
+    "AbstractHTML": "The <span class=\"pkgname\">AClib</span> package contains a library of almost crystallographic groups and a some algorithms to compute with these groups. A group is called almost crystallographic if it is finitely generated nilpotent-by-finite and has no non-trivial finite normal subgroups. Further, an almost crystallographic group is called almost Bieberbach if it is torsion-free. The almost crystallographic groups of Hirsch length 3 and a part of the almost cyrstallographic groups of Hirsch length 4 have been classified by Dekimpe. This classification includes all almost Bieberbach groups of Hirsch lengths 3 or 4. The AClib package gives access to this classification; that is, the package contains this library of groups in a computationally useful form. The groups in this library are available in two different representations. First, each of the groups of Hirsch length 3 or 4 has a rational matrix representation of dimension 4 or 5, respectively, and such representations are available in this package. Secondly, all the groups in this libraray are (infinite) polycyclic groups and the package also incorporates polycyclic presentations for them. The polycyclic presentations can be used to compute with the given groups using the methods of the Polycyclic package."
   },
   "alnuth": {
     "Version": "3.1.2",
@@ -5650,7 +5552,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/alnuth",
     "IssueTrackerURL": "https://github.com/gap-packages/alnuth/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/alnuth"
@@ -5662,9 +5563,7 @@
     "ArchiveURL": "https://github.com/gap-packages/alnuth/releases/download/v3.1.2/alnuth-3.1.2",
     "README_URL": "https://gap-packages.github.io/alnuth/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/alnuth/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">Alnuth</span> package provides various methods to compute with number fields which are given by a defining polynomial or by generators. Some of the methods provided in this package are written in <span class=\"pkgname\">GAP</span> code. The other part of the methods is imported from the computer algebra system PARI/GP. Hence this package contains some <span class=\"pkgname\">GAP</span> functions and an interface to some functions in the computer algebra system PARI/GP. The main methods included in <span class=\"pkgname\">Alnuth</span> are: creating a number field, computing its maximal order (using PARI/GP), computing its unit group (using PARI/GP) and a presentation of this unit group, computing the elements of a given norm of the number field (using PARI/GP), determining a presentation for a finitely generated multiplicative subgroup (using PARI/GP), and factoring polynomials defined over number fields (using PARI/GP).",
-    "CommunicatedBy": "Charles Wright (Eugene)",
-    "AcceptDate": "01/2004"
+    "AbstractHTML": "The <span class=\"pkgname\">Alnuth</span> package provides various methods to compute with number fields which are given by a defining polynomial or by generators. Some of the methods provided in this package are written in <span class=\"pkgname\">GAP</span> code. The other part of the methods is imported from the computer algebra system PARI/GP. Hence this package contains some <span class=\"pkgname\">GAP</span> functions and an interface to some functions in the computer algebra system PARI/GP. The main methods included in <span class=\"pkgname\">Alnuth</span> are: creating a number field, computing its maximal order (using PARI/GP), computing its unit group (using PARI/GP) and a presentation of this unit group, computing the elements of a given norm of the number field (using PARI/GP), determining a presentation for a finitely generated multiplicative subgroup (using PARI/GP), and factoring polynomials defined over number fields (using PARI/GP)."
   },
   "atlasrep": {
     "Version": "2.1.0",
@@ -5772,7 +5671,6 @@
       }
     ],
     "PackageWWWHome": "http://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep",
-    "Status": "accepted",
     "Subtitle": "A GAP Interface to the Atlas of Group Representations",
     "TestFile": "tst/testauto.g",
     "License": "GPL-3.0-or-later",
@@ -5781,8 +5679,6 @@
     "README_URL": "http://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/README.md",
     "PackageInfoURL": "http://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/PackageInfo.g",
     "AbstractHTML": "The package provides a <span class=\"pkgname\">GAP</span> interface to the <a href=\"http://brauer.maths.qmul.ac.uk/Atlas/v3\">Atlas of Group Representations</a>",
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
-    "AcceptDate": "04/2001",
     "MyVersion": "2r1p0",
     "MyWWWHome": "http://www.math.rwth-aachen.de/~Thomas.Breuer"
   },
@@ -5850,7 +5746,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/automata/",
     "IssueTrackerURL": "https://github.com/gap-packages/automata/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/automata"
@@ -5862,9 +5757,7 @@
     "README_URL": "https://gap-packages.github.io/automata/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/automata/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">Automata</span> package, as its name suggests, is package with algorithms to deal with automata.",
-    "Autoload": false,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
-    "AcceptDate": "09/2004"
+    "Autoload": false
   },
   "automgrp": {
     "Version": "1.3.2",
@@ -5933,7 +5826,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/automgrp",
     "IssueTrackerURL": "https://github.com/gap-packages/automgrp/issues",
     "BannerString": "----------------------------------------------------------------\n     ^                                    ___                   \n    / \\                                  /   \\                  \n   /   \\           _______  ___         ||        ___   __      \n  /_____\\   ||  ||    |    /   \\  |\\ /| ||   __ |/   | |  \\    \n /       \\  ||  ||    |   ||   || | V | ||   || |      |__/    \n/         \\  \\__/     |    \\___/  |   |  \\___/  |      |        \n                                                                \nLoading  AutomGrp 1.3.2 (Automata Groups and Semigroups)\nby Yevgen Muntyan (muntyan@fastmail.fm)\n   Dmytro Savchuk (http://savchuk.myweb.usf.edu/)\nHomepage: https://gap-packages.github.io/automgrp\n----------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/automgrp"
@@ -5946,9 +5838,7 @@
     "README_URL": "https://gap-packages.github.io/automgrp/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/automgrp/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">AutomGrp</span> package provides methods for computations with groups and semigroups generated by finite automata or given by wreath recursion, as well as with their finitely generated subgroups and elements.",
-    "Autoload": true,
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
-    "AcceptDate": "03/2016"
+    "Autoload": true
   },
   "circle": {
     "Version": "1.6.3",
@@ -6011,7 +5901,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/circle",
     "IssueTrackerURL": "https://github.com/gap-packages/circle/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/circle"
@@ -6023,9 +5912,7 @@
     "ArchiveURL": "https://github.com/gap-packages/circle/releases/download/v1.6.3/circle-1.6.3",
     "README_URL": "https://gap-packages.github.io/circle/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/circle/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">Circle</span> package provides functionality for computations in adjoint groups of finite associative rings. It allows to construct circle objects that will respect the circle multiplication r*s=r+s+rs, create multiplicative groups, generated by such objects, and compute groups of elements, invertible with respect to this operation. Also it may serve as an example of extending the GAP system with new multiplicative objects.",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "01/2008"
+    "AbstractHTML": "The <span class=\"pkgname\">Circle</span> package provides functionality for computations in adjoint groups of finite associative rings. It allows to construct circle objects that will respect the circle multiplication r*s=r+s+rs, create multiplicative groups, generated by such objects, and compute groups of elements, invertible with respect to this operation. Also it may serve as an example of extending the GAP system with new multiplicative objects."
   },
   "cohomolo": {
     "Version": "1.6.8",
@@ -6079,7 +5966,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/cohomolo",
     "IssueTrackerURL": "https://github.com/gap-packages/cohomolo/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/cohomolo"
@@ -6092,9 +5978,7 @@
     "README_URL": "https://gap-packages.github.io/cohomolo/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/cohomolo/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">cohomolo</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for computing Schur multipliers and covering groups of finite groups   and first and second cohomology groups of finite groups acting   on finite modules",
-    "Autoload": false,
-    "CommunicatedBy": "unknown (unknown)",
-    "AcceptDate": "01/1970"
+    "Autoload": false
   },
   "congruence": {
     "Version": "1.2.3",
@@ -6177,7 +6061,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/congruence",
     "IssueTrackerURL": "https://github.com/gap-packages/congruence/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/congruence"
@@ -6189,9 +6072,7 @@
     "ArchiveURL": "https://github.com/gap-packages/congruence/releases/download/v1.2.3/congruence-1.2.3",
     "README_URL": "https://gap-packages.github.io/congruence/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/congruence/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">Congruence </span> package provides functions to construct several types of canonical congruence subgroups in SL_2(Z), and also intersections of a finite number of such subgroups. Furthermore, it implements the algorithm for generating Farey symbols for congruence subgroups and using them to produce a system of independent generators for these subgroups",
-    "CommunicatedBy": "Graham Ellis (Galway)",
-    "AcceptDate": "09/2014"
+    "AbstractHTML": "The <span class=\"pkgname\">Congruence </span> package provides functions to construct several types of canonical congruence subgroups in SL_2(Z), and also intersections of a finite number of such subgroups. Furthermore, it implements the algorithm for generating Farey symbols for congruence subgroups and using them to produce a system of independent generators for these subgroups"
   },
   "corelg": {
     "Version": "1.54",
@@ -6262,7 +6143,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/corelg/",
     "IssueTrackerURL": "https://github.com/gap-packages/corelg/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/corelg"
@@ -6282,9 +6162,7 @@
         "Abstract": "\n      This package provides functions for computing with various\n      aspects of the theory of real simple Lie algebras.\n      ",
         "Acknowledgements": "\n      The research leading to this package has received funding from\n      the European Union's Seventh Framework Program FP7/2007-2013\n      under grant agreement no 271712, and from the Australian Research\n      Council, grantor code DE140100088 and DP190100317.\n      "
       }
-    },
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
-    "AcceptDate": "01/2014"
+    }
   },
   "crime": {
     "Version": "1.5",
@@ -6333,7 +6211,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/crime/",
     "IssueTrackerURL": "https://github.com/gap-packages/crime/issues",
     "BannerString": "\nThis is CRIME, Version 1.5\n\"Obviously crime pays, or there'd be no crime\".\n                                G. Gordon Liddy\n\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/crime"
@@ -6351,9 +6228,7 @@
         "Copyright": "\n&copyright; 2006, 2007 Marcus Bishop <P/>\n<Package>CRIME</Package> is free software which is distributed under\nthe GNU Public Licence, version 2, and may be\nredistributed under the GNU Public Licence, version 2\nor later (at your preference).\nSee the file COPYING for detailed information\n",
         "Acknowledgements": "\nThis project would not have been possible without Jon Carlson.\nJon devised the algorithms used by <K>ProjectiveResolution</K>,\n<K>CohomologyGenerators</K>, and <K>CohomologyRelators</K>,\nhaving already implemented them in <Package>Magma</Package>,\nand shared these programs with me.\n"
       }
-    },
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
-    "AcceptDate": "10/2006"
+    }
   },
   "crisp": {
     "Version": "1.4.5",
@@ -6410,7 +6285,6 @@
     "BinaryFiles": [
       "doc/manual.pdf"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/bh11/crisp.git"
@@ -6422,9 +6296,7 @@
     "README_URL": "http://www.icm.tu-bs.de/~bhoeflin/crisp/README",
     "PackageInfoURL": "http://www.icm.tu-bs.de/~bhoeflin/crisp/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">CRISP</span> provides algorithms for computing subgroups of finite soluble groups related to a group class <i>C</i>. In particular, it allows to compute <i>C</i>-radicals and <i>C</i>-injectors for Fitting classes (and Fitting sets) <i>C</i>, <i>C</i>-residuals for formations <i>C</i>, and <i>C</i>-projectors for Schunck classes <i>C</i>. In order to carry out these computations, the group class <i>C</i> must be represented by an algorithm which can decide membership in the group class.</p>  <p>Moreover, <span class=\"pkgname\">CRISP</span> contains algorithms for the computation of normal subgroups invariant under a prescribed set of automorphisms and belonging to a given group class.</p>  <p>This includes an improved method to compute the set of all normal subgroups of a finite soluble group, its characteristic subgroups, minimal normal subgroups and the socle and <i>p</i>-socles for given primes <i>p</i>.",
-    "Autoload": true,
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
-    "AcceptDate": "12/2000"
+    "Autoload": true
   },
   "crypting": {
     "Version": "0.10",
@@ -6474,7 +6346,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/crypting/",
     "IssueTrackerURL": "https://github.com/gap-packages/crypting/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/crypting"
@@ -6582,7 +6453,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/cryst"
@@ -6595,9 +6465,7 @@
     "README_URL": "https://www.math.uni-bielefeld.de/~gaehler/gap/Cryst/README.cryst",
     "PackageInfoURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/Cryst/PackageInfo.g",
     "AbstractHTML": "This package, previously known as <span class=\"pkgname\">CrystGAP</span>, provides a rich set of methods for the computation with affine crystallographic groups, in particular space groups. Affine crystallographic groups are fully supported both in representations acting from the right or from the left, the latter one being preferred by crystallographers. Functions to determine representatives of all space group types of a given dimension are also provided. Where necessary, <span class=\"pkgname\">Cryst</span> can also make use of functionality provided by the package <span class=\"pkgname\">CaratInterface</span>.",
-    "SupportEmail": "gaehler@math.uni-bielefeld.de",
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
-    "AcceptDate": "02/2000"
+    "SupportEmail": "gaehler@math.uni-bielefeld.de"
   },
   "crystcat": {
     "Version": "1.1.9",
@@ -6661,7 +6529,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/crystcat"
@@ -6674,9 +6541,7 @@
     "README_URL": "https://www.math.uni-bielefeld.de/~gaehler/gap45/CrystCat/README.crystcat",
     "PackageInfoURL": "https://www.math.uni-bielefeld.de/~gaehler/gap45/CrystCat/PackageInfo.g",
     "AbstractHTML": "This package provides a catalog of crystallographic groups of dimensions 2, 3, and 4 which covers most of the data contained in the book <em>Crystallographic groups of four-dimensional space</em> by H. Brown, R. B&uuml;low, J. Neub&uuml;ser, H. Wondratschek, and H. Zassenhaus (John Wiley, New York, 1978). Methods for the computation with these groups are provided by the package <span class=\"pkgname\">Cryst</span>, which must be installed as well.",
-    "SupportEmail": "gaehler@math.uni-bielefeld.de",
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
-    "AcceptDate": "02/2000"
+    "SupportEmail": "gaehler@math.uni-bielefeld.de"
   },
   "ctbllib": {
     "Version": "1.2.2",
@@ -6752,7 +6617,6 @@
       }
     ],
     "PackageWWWHome": "http://www.math.rwth-aachen.de/~Thomas.Breuer/ctbllib",
-    "Status": "deposited",
     "Subtitle": "The GAP Character Table Library",
     "TestFile": "tst/testauto.g",
     "ArchiveFormats": ".tar.gz",
@@ -6817,7 +6681,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/cubefree/",
     "IssueTrackerURL": "https://github.com/gap-packages/cubefree/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/cubefree"
@@ -6830,9 +6693,7 @@
     "README_URL": "https://gap-packages.github.io/cubefree/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/cubefree/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">Cubefree</span> package contains methods to construct up to isomorphism the groups of a given (reasonable) cubefree order. The main function ConstructAllCFGroups(n) constructs all groups of a given cubefree order n. The function NumberCFGroups(n) counts all groups of a cubefree order n. Furthermore, IrreducibleSubgroupsOfGL(2,q) constructs the irreducible subgroups of GL(2,q), q=p^r, p>=5 prime, up to conjugacy and RewriteAbsolutelyIrreducibleMatrixGroup(G) rewrites the absolutely irreducible matrix group G (over a finite field) over a minimal subfield.",
-    "Autoload": false,
-    "CommunicatedBy": "David Joyner (Annapolis)",
-    "AcceptDate": "10/2007"
+    "Autoload": false
   },
   "curlinterface": {
     "Version": "2.1.1",
@@ -6888,7 +6749,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/curlInterface/",
     "IssueTrackerURL": "https://github.com/gap-packages/curlInterface/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/curlInterface"
@@ -6962,7 +6822,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/cvec",
     "IssueTrackerURL": "https://github.com/gap-packages/cvec/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/cvec"
@@ -7061,7 +6920,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/datastructures",
     "IssueTrackerURL": "https://github.com/gap-packages/datastructures/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/datastructures"
@@ -7142,7 +7000,6 @@
       "doc/manual.dvi",
       "doc/manual.pdf"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/design"
@@ -7154,9 +7011,7 @@
     "ArchiveURL": "https://github.com/gap-packages/design/releases/download/v1.7/design-1.7",
     "README_URL": "https://gap-packages.github.io/design/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/design/PackageInfo.g",
-    "AbstractHTML": "<span class=\"pkgname\">DESIGN</span> is a package for constructing, classifying, partitioning, and studying block designs.",
-    "CommunicatedBy": "Akos Seress (Ohio State)",
-    "AcceptDate": "08/2006"
+    "AbstractHTML": "<span class=\"pkgname\">DESIGN</span> is a package for constructing, classifying, partitioning, and studying block designs."
   },
   "difsets": {
     "Version": "2.3.1",
@@ -7210,7 +7065,6 @@
     ],
     "PackageWWWHome": "https://dylanpeifer.github.io/difsets",
     "IssueTrackerURL": "https://github.com/dylanpeifer/difsets/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/dylanpeifer/difsets"
@@ -7229,9 +7083,7 @@
         "Copyright": "\n                Copyright &copyright; 2017, 2019 Dylan Peifer <P/>\n\n                This program is free software: you can redistribute it and/or\n                modify it under the terms of the GNU General Public License as\n                published by the Free Software Foundation, either version 3 of\n                the License, or (at your option) any later version. <P/>\n\n                This program is distributed in the hope that it will be useful,\n                but WITHOUT ANY WARRANTY; without even the implied warranty of\n                MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the\n                GNU General Public License for more details. <P/>\n\n                You should have received a copy of the GNU General Public\n                License along with this program. If not, see\n                <URL>http://www.gnu.org/licenses/</URL>.\n            ",
         "Abstract": "\n                The <Package>DifSets</Package> Package implements an algorithm\n                for enumerating all difference sets up to equivalence in an\n                arbitrary finite group. The algorithm functions by finding\n                difference sums, which are potential images of difference sets\n                in quotient groups of the original group, and searching their\n                preimages. In this way, the search space can be dramatically\n                decreased, and searches of groups of relatively large order\n                (such as order 64 or order 96) can be completed.\n            "
       }
-    },
-    "CommunicatedBy": "Alexander Hulpke (Colorado State)",
-    "AcceptDate": "07/2019"
+    }
   },
   "digraphs": {
     "Version": "1.1.1",
@@ -7432,7 +7284,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/Digraphs",
     "IssueTrackerURL": "https://github.com/gap-packages/Digraphs/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/Digraphs"
@@ -7494,7 +7345,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/ferret/",
     "IssueTrackerURL": "https://github.com/gap-packages/ferret/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/ferret"
@@ -7554,7 +7404,6 @@
     ],
     "PackageWWWHome": "http://www.icm.tu-bs.de/ag_algebra/software/FGA/",
     "IssueTrackerURL": "https://github.com/chsievers/fga/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/chsievers/fga"
@@ -7566,9 +7415,7 @@
     "README_URL": "http://www.icm.tu-bs.de/ag_algebra/software/FGA/README",
     "PackageInfoURL": "http://www.icm.tu-bs.de/ag_algebra/software/FGA/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">FGA</span> package installs methods for    computations with finitely generated subgroups of free groups and    provides a presentation for their automorphism groups.",
-    "Autoload": true,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
-    "AcceptDate": "05/2005"
+    "Autoload": true
   },
   "fining": {
     "Version": "1.4.1",
@@ -7695,7 +7542,6 @@
     "PackageWWWHome": "http://www.fining.org",
     "IssueTrackerURL": "https://bitbucket.org/jdebeule/fining/issues",
     "BannerString": "-------------------------------------------------------------------------------\n         ______________       ________      _________   __________ __          \n         ___  ____/__(_)__________  _/________  ____/   __<  /_  // /          \n         __  /_   __  /__  __ __  / __  __   / __     __  /_  // /_          \n         _  __/   _  / _  / / /_/ /  _  / / / /_/ /     _  /_/__  __/          \n         /_/      /_/  /_/ /_//___/  /_/ /_/____/      /_/_(_)/_/             \n-------------------------------------------------------------------------------\nLoading  FinInG 1.4.1 (Finite Incidence Geometry) \nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Anton Betten (http://www.math.colostate.edu/~betten)\n   Jan De Beule (http://www.debeule.eu)\n   Philippe Cara (http://homepages.vub.ac.be/~pcara)\n   Michel Lavrauw (http://people.sabanciuniv.edu/~mlavrauw/)\n   Max Neunhoeffer (http://www-groups.mcs.st-and.ac.uk/~neunhoef/)\nFor help, type: ?FinInG \n---------------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://bitbucket.org/jdebeule/fining"
@@ -7706,9 +7552,7 @@
     "ArchiveURL": "http://cage.ugent.be/fining/archive/fining-1.4.1",
     "README_URL": "http://cage.ugent.be/fining/README",
     "PackageInfoURL": "http://cage.ugent.be/fining/PackageInfo.g",
-    "AbstractHTML": "<span class=\"pkgname\">FinInG</span> is a package for computation in Finite Incidence Geometry. It provides users with the basic tools to work in  various areas of finite geometry from the realms of projective spaces to the flat  lands of generalised polygons. The algebraic power of GAP is employed, particularly  in its facility with matrix and permutation groups.",
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
-    "AcceptDate": "11/2017"
+    "AbstractHTML": "<span class=\"pkgname\">FinInG</span> is a package for computation in Finite Incidence Geometry. It provides users with the basic tools to work in  various areas of finite geometry from the realms of projective spaces to the flat  lands of generalised polygons. The algebraic power of GAP is employed, particularly  in its facility with matrix and permutation groups."
   },
   "float": {
     "Version": "0.9.1",
@@ -7760,7 +7604,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/float/",
     "IssueTrackerURL": "https://github.com/gap-packages/float/issues",
     "BannerString": "float 0.9.1 ...\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/float"
@@ -7834,7 +7677,6 @@
     ],
     "PackageWWWHome": "http://cage.ugent.be/geometry/forms.php",
     "BannerString": "---------------------------------------------------------------------\nLoading 'Forms' 1.2.5 (27/09/2018)\nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Jan De Beule (http://www.debeule.eu)\nFor help, type: ?Forms \n---------------------------------------------------------------------\n",
-    "Status": "accepted",
     "Subtitle": "Sesquilinear and Quadratic",
     "TestFile": "tst/testall.g",
     "ArchiveFormats": ".tar.gz -win.zip .tar.bz2",
@@ -7842,9 +7684,7 @@
     "README_URL": "http://cage.ugent.be/geometry/software/forms/README",
     "PackageInfoURL": "http://cage.ugent.be/geometry/software/forms/PackageInfo.g",
     "AbstractHTML": "This package can be used for work with sesquilinear and quadratic forms on finite vector spaces; objects that are used to describe polar spaces and classical groups.",
-    "Autoload": false,
-    "CommunicatedBy": "Leonard Soicher (London)",
-    "AcceptDate": "03/2009"
+    "Autoload": false
   },
   "fr": {
     "Version": "2.4.6",
@@ -7921,7 +7761,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/fr",
     "IssueTrackerURL": "https://github.com/gap-packages/fr/issues",
     "BannerString": "Loading FR 2.4.6 ...\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/fr"
@@ -7933,8 +7772,7 @@
     "README_URL": "https://gap-packages.github.io/fr/README",
     "PackageInfoURL": "https://gap-packages.github.io/fr/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">fr</span> package allows    GAP to manipulate groups generated by automata, and more generally    functionally recursive groups",
-    "Autoload": false,
-    "CommunicatedBy": "G\u00f6tz Pfeiffer (NUI Galway)"
+    "Autoload": false
   },
   "francy": {
     "Version": "1.2.4",
@@ -7995,7 +7833,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/francy",
     "IssueTrackerURL": "https://github.com/gap-packages/Francy/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/Francy"
@@ -8089,7 +7926,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/fwtree/",
     "IssueTrackerURL": "https://github.com/gap-packages/fwtree/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/fwtree"
@@ -8161,7 +7997,6 @@
       }
     ],
     "PackageWWWHome": "http://mathdox.org/products/gbnp/",
-    "Status": "accepted",
     "Subtitle": "computing Gr\u00f6bner bases of noncommutative polynomials",
     "TestFile": "test/test-all.tst",
     "ArchiveFormats": ".tar.gz",
@@ -8169,9 +8004,7 @@
     "README_URL": "http://mathdox.org/products/gbnp/README",
     "PackageInfoURL": "http://mathdox.org/products/gbnp/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">GBNP</spam> package provides algorithms for    computing Grobner bases of noncommutative polynomials with coefficients    from a field implemented in <span class=\"pkgname\">GAP</span> and with    respect to the \"total degree first then lexicographical\" ordering.    Further provided are some variations, such as a weighted and truncated    version and a tracing facility. The word \"algorithm\" is to be    interpreted loosely here: in general one cannot expect such an algorithm    to terminate, as it would imply solvability of the word problem for    finitely presented (semi)groups.",
-    "Autoload": false,
-    "CommunicatedBy": "Alexander Hulpke (Fort Collins, CO)",
-    "AcceptDate": "05/2010"
+    "Autoload": false
   },
   "genss": {
     "Version": "1.6.6",
@@ -8250,7 +8083,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/genss",
     "IssueTrackerURL": "https://github.com/gap-packages/genss/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/genss"
@@ -8319,7 +8151,6 @@
       "nauty22/nug.pdf",
       "bin/i686-pc-cygwin-gcc-default32/dreadnautB.exe"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/grape"
@@ -8330,9 +8161,7 @@
     "ArchiveURL": "https://github.com/gap-packages/grape/releases/download/v4.8.3/grape-4.8.3",
     "README_URL": "https://gap-packages.github.io/grape/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/grape/PackageInfo.g",
-    "AbstractHTML": "<span class=\"pkgname\">GRAPE</span> is a package for computing with graphs and groups, and is primarily designed for constructing and analysing graphs related to groups, finite geometries, and designs.",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "07/1993"
+    "AbstractHTML": "<span class=\"pkgname\">GRAPE</span> is a package for computing with graphs and groups, and is primarily designed for constructing and analysing graphs related to groups, finite geometries, and designs."
   },
   "groupoids": {
     "Version": "1.68",
@@ -8410,7 +8239,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/groupoids/",
     "IssueTrackerURL": "https://github.com/gap-packages/groupoids/issues",
     "BannerString": "Loading groupoids 1.68 (algorithms for finite groupoids)\nby Emma Moore and Chris Wensley (http://pages.bangor.ac.uk/~mas023/)\n--------------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/groupoids"
@@ -8431,9 +8259,7 @@
         "Abstract": "The &groupoids; package provides functions for computation with\ngroupoids (categories with every arrow invertible) and their morphisms; for graphs of groups, and graphs of groupoids.\nThe most basic structure introduced is that of <E>magma with objects</E>, followed by <E>semigroup with objects</E>, then <E>monoid with objects</E> and finally <E>groupoid</E> which is a <E>group with objects</E>.\n <P/>It provides normal forms for Free Products with Amalgamation and for HNN-extensions when the initial groups have rewrite systems and the subgroups have finite index. This is described in Section <Ref Sect=\"sec-gphgps\"/>. It is planned to move this section to a new package <Package>Rewriting</Package> in time for version 4.11 of &GAP;.\n<P/>The &groupoids; package was originally implemented in 2000 (as <Package>GraphGpd</Package>) when the first author was studying for a Ph.D. in Bangor.\n <P/>The package was then renamed <Package>Gpd</Package> and version 1.07 was released in July 2011, ready for &GAP; 4.5.\n <P/><Package>Gpd</Package> became an accepted &GAP; package in May 2015.\n <P/>In April 2017 the package was renamed again, as <Package>groupoids</Package>.\n <P/>Recent versions implement many of the constructions described in the paper <Cite Key='AlWe' /> for automorphisms of groupoids.\n <P/>Bug reports, comments, suggestions for additional features, and offers to implement some of these, will all be very welcome.\n <P/>Please submit any issues at <URL>https://github.com/gap-packages/groupoids/issues/</URL> or send an email to the second author at <Email>c.d.wensley@bangor.ac.uk</Email>.\n <P/>",
         "Acknowledgements": "This documentation was prepared using the &GAPDoc; <Cite Key='GAPDoc'/> and &AutoDoc; <Cite Key='AutoDoc'/> packages.<P/>\nThe procedure used to produce new releases uses the package <Package>GitHubPagesForGAP</Package> <Cite Key='GitHubPagesForGAP' /> and the package <Package>ReleaseTools</Package>.<P/>"
       }
-    },
-    "CommunicatedBy": "Derek Holt (Warwick)",
-    "AcceptDate": "05/2015"
+    }
   },
   "grpconst": {
     "Version": "2.6.2",
@@ -8508,7 +8334,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/grpconst/",
     "IssueTrackerURL": "https://github.com/gap-packages/grpconst/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/grpconst"
@@ -8520,9 +8345,7 @@
     "ArchiveURL": "https://github.com/gap-packages/grpconst/releases/download/v2.6.2/grpconst-2.6.2",
     "README_URL": "https://gap-packages.github.io/grpconst/README",
     "PackageInfoURL": "https://gap-packages.github.io/grpconst/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">GrpConst</span> package contains methods to construct up to isomorphism the groups of a given order. The FrattiniExtensionMethod constructs all soluble groups of a given order. On request it gives only those that are (or are not) nilpotent or supersolvable or that do (or do not) have normal Sylow subgroups for some given set of primes. The CyclicSplitExtensionMethod constructs all groups having a normal Sylow subgroup for orders of the type p^n *q. The method relies on the availability of a list of all groups of order p^n. The UpwardsExtensions algorithm takes as input a permutation group G and a positive integer s and returns a list of permutation groups, one for each extension of G by a soluble group of order a divisor of s. This method can used to construct the non-solvable groups of a given order by taking the perfect groups of certain orders as input for G. The programs in this package have been used to construct a large part of the Small Groups library.",
-    "CommunicatedBy": "Charles Wright (Eugene)",
-    "AcceptDate": "07/1999"
+    "AbstractHTML": "The <span class=\"pkgname\">GrpConst</span> package contains methods to construct up to isomorphism the groups of a given order. The FrattiniExtensionMethod constructs all soluble groups of a given order. On request it gives only those that are (or are not) nilpotent or supersolvable or that do (or do not) have normal Sylow subgroups for some given set of primes. The CyclicSplitExtensionMethod constructs all groups having a normal Sylow subgroup for orders of the type p^n *q. The method relies on the availability of a list of all groups of order p^n. The UpwardsExtensions algorithm takes as input a permutation group G and a positive integer s and returns a list of permutation groups, one for each extension of G by a soluble group of order a divisor of s. This method can used to construct the non-solvable groups of a given order by taking the perfect groups of certain orders as input for G. The programs in this package have been used to construct a large part of the Small Groups library."
   },
   "guarana": {
     "Version": "0.96.2",
@@ -8608,7 +8431,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/guarana/",
     "IssueTrackerURL": "https://github.com/gap-packages/guarana/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/guarana"
@@ -8771,7 +8593,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/guava",
     "IssueTrackerURL": "https://github.com/gap-packages/guava/issues",
     "BannerString": "\n   ____                          |\n  /            \\           /   --+--  Version 3.15\n /      |    | |\\\\        //|    |\n|    _  |    | | \\\\      // |     the GUAVA Group\n|     \\ |    | |--\\\\    //--|     \n \\     ||    | |   \\\\  //   |     \n  \\___/  \\___/ |    \\\\//    |      \n                                  \n\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/guava"
@@ -8783,9 +8604,7 @@
     "README_URL": "https://gap-packages.github.io/guava/README.guava",
     "PackageInfoURL": "https://gap-packages.github.io/guava/PackageInfo.g",
     "AbstractHTML": "<span class=\"pkgname\">GUAVA</span> is a <span class=\"pkgname\">GAP</span> package for computing with codes. <span class=\"pkgname\">GUAVA</span> can construct unrestricted (non-linear), linear and cyclic codes; transform one code into another (for example by puncturing); construct a new code from two other codes (using direct sums for example); perform decoding/error-correction; and can calculate important data of codes (such as the minumim distance or covering radius) quickly. Limited ability to compute algebraic geometric codes.",
-    "Autoload": false,
-    "CommunicatedBy": "Charles Wright (Eugene)",
-    "AcceptDate": "02/2003"
+    "Autoload": false
   },
   "hap": {
     "Version": "1.25",
@@ -8910,7 +8729,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/hap",
     "IssueTrackerURL": "https://github.com/gap-packages/hap/issues",
     "BannerString": "Loading HAP 1.25 ...\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/hap"
@@ -8921,9 +8739,7 @@
     "ArchiveURL": "https://github.com/gap-packages/hap/releases/download/v1.25/hap-1.25",
     "README_URL": "https://gap-packages.github.io/hap/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/hap/PackageInfo.g",
-    "AbstractHTML": "This package provides some functions for group cohomology. ",
-    "CommunicatedBy": "Derek Holt (Warwick)",
-    "AcceptDate": "03/2006"
+    "AbstractHTML": "This package provides some functions for group cohomology. "
   },
   "hapcryst": {
     "Version": "0.1.13",
@@ -9019,7 +8835,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/hapcryst/",
     "IssueTrackerURL": "https://github.com/gap-packages/hapcryst/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/hapcryst"
@@ -9091,7 +8906,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/hecke/",
     "IssueTrackerURL": "https://github.com/gap-packages/hecke/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/hecke"
@@ -9188,7 +9002,6 @@
       }
     ],
     "PackageWWWHome": "https://homalg-project.github.io/homalg_project/homalg/",
-    "Status": "deposited",
     "Subtitle": "A homological algebra meta-package for computable Abelian categories",
     "License": "GPL-2.0-or-later",
     "ArchiveFormats": ".tar.gz .zip",
@@ -9259,7 +9072,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/idrel/",
     "IssueTrackerURL": "https://github.com/gap-packages/idrel/issues",
     "BannerString": "Loading IdRel 2.43 (Identities among Relations)\nby Anne Heyworth and Chris Wensley (http://pages.bangor.ac.uk/~mas023/)\n-----------------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/idrel"
@@ -9279,9 +9091,7 @@
         "Abstract": "&IdRel; is a &GAP; package originally implemented in 1999, using the &GAP; 3 language, when the first author was studying for a Ph.D. in Bangor.\n<P/>\nThis package is designed to compute a minimal set of generators for the module of the identities among relators of a group presentation.\nIt does this using\n<List>\n<Item>\nrewriting and logged rewriting: a self-contained implementation of the Knuth-Bendix process using the monoid presentation associated to the group presentation;\n</Item>\n<Item>\nmonoid polynomials: an implementation of the monoid ring;\n</Item>\n<Item>\nmodule polynomials: an implementation of the right module over this monoid generated by the relators.\n</Item>\n<Item>\nY-sequences: used as a <E>rewriting</E> way of representing elements of a free crossed module (products of conjugates of group relators and inverse relators).\n</Item>\n</List>\n<P/>\n&idrel; became an accepted &GAP; package in May 2015.\n<P/>\nBug reports, suggestions and comments are, of course, welcome.\nPlease contact the last author at <Email>c.d.wensley@bangor.ac.uk</Email> or submit an issue at the GitHub repository <URL>https://github.com/gap-packages/idrel/issues/</URL>.\n",
         "Acknowledgements": "This documentation was prepared using the &GAPDoc; <Cite Key='GAPDoc'/> and &AutoDoc; <Cite Key='AutoDoc'/> packages.<P/>\nThe procedure used to produce new releases uses the package <Package>GitHubPagesForGAP</Package> <Cite Key='GitHubPagesForGAP' /> and the package <Package>ReleaseTools</Package>.<P/>"
       }
-    },
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "05/2015"
+    }
   },
   "images": {
     "Version": "1.3.0",
@@ -9360,7 +9170,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/images/",
     "IssueTrackerURL": "https://github.com/gap-packages/images/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/images"
@@ -9441,7 +9250,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/io",
     "IssueTrackerURL": "https://github.com/gap-packages/io/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/io"
@@ -9521,7 +9329,6 @@
       "B*.pdf",
       "T*"
     ],
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/bh11/irredsol.git"
@@ -9533,9 +9340,7 @@
     "README_URL": "http://www.icm.tu-bs.de/~bhoeflin/irredsol/README",
     "PackageInfoURL": "http://www.icm.tu-bs.de/~bhoeflin/irredsol/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">IRREDSOL</span> provides a library of all irreducible soluble subgroups of <i>GL(n,q)</i>, up to conjugacy, for <i>q<sup>n</sup></i> up to 2^24-1, and a library of the primitive soluble groups of degree up to 2^24-1.",
-    "Autoload": true,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
-    "AcceptDate": "08/2006"
+    "Autoload": true
   },
   "itc": {
     "Version": "1.5",
@@ -9609,7 +9414,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/itc/",
     "IssueTrackerURL": "https://github.com/gap-packages/itc/issues",
     "BannerString": "\n          Loading  ITC 1.5  (Interactive Todd-Coxeter)\n            by V. Felsch, L. Hippe, and J. Neubueser\n              (Volkmar.Felsch@math.rwth-aachen.de)\n\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/itc"
@@ -9620,9 +9424,7 @@
     "README_URL": "https://gap-packages.github.io/itc/README",
     "PackageInfoURL": "https://gap-packages.github.io/itc/PackageInfo.g",
     "AbstractHTML": "This <span class=\"pkgname\">GAP</span> package provides    access to interactive Todd-Coxeter computations    with finitely presented groups.",
-    "Autoload": false,
-    "CommunicatedBy": "Edmund F. Robertson (St Andrews)",
-    "AcceptDate": "03/2000"
+    "Autoload": false
   },
   "json": {
     "Version": "2.0.1",
@@ -9667,7 +9469,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/json/",
     "IssueTrackerURL": "https://github.com/gap-packages/json/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/json"
@@ -9736,7 +9537,6 @@
     ],
     "PackageWWWHome": "https://nathancarter.github.io/jupyterviz",
     "IssueTrackerURL": "https://github.com/nathancarter/jupyterviz/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/nathancarter/jupyterviz"
@@ -9815,7 +9615,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/kan/",
     "IssueTrackerURL": "https://github.com/gap-packages/kan/issues",
     "BannerString": "Loading Kan 1.29 (computing with Kan extensions)\nby Anne Heyworth and Chris Wensley (http://pages.bangor.ac.uk/~mas023/)\n-----------------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/kan"
@@ -9835,9 +9634,7 @@
         "Abstract": "&Kan; is a &GAP; package originally implemented in 1996 using the &GAP; 3 language, to compute induced actions of categories, when the first author was studying for a Ph.D. in Bangor.\n<P/>\nThis reduced version only provides functions for the computation of normal forms of representatives of double cosets of finitely presented groups.\n<P/>\n&Kan; became an accepted &GAP; package in May 2015.\n<P/>\nBug reports, suggestions and comments are, of course, welcome.\nPlease contact the last author at <Email>c.d.wensley@bangor.ac.uk</Email> or submit an issue at the GitHub repository <URL>https://github.com/gap-packages/kan/issues/</URL>.\n",
         "Acknowledgements": "This documentation was prepared using the &GAPDoc; <Cite Key='GAPDoc'/> and &AutoDoc; <Cite Key='AutoDoc'/> packages.<P/>\nThe procedure used to produce new releases uses the package <Package>GitHubPagesForGAP</Package> <Cite Key='GitHubPagesForGAP' /> and the package <Package>ReleaseTools</Package>.<P/>"
       }
-    },
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "05/2015"
+    }
   },
   "kbmag": {
     "Version": "1.5.9",
@@ -9889,7 +9686,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/kbmag",
     "IssueTrackerURL": "https://github.com/gap-packages/kbmag/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/kbmag"
@@ -9909,9 +9705,7 @@
         "Abstract": "The &KBMAG; package is a &GAP; interface to some `C' programs for running the Knuth-Bendix completion program on finite semigroup, monoid or group presentations, and for attempting to compute  automatic structures of finitely presented groups.<P/>Bug reports, comments, suggestions for additional features, and offers to implement some of these, will all be very welcome.<P/>Please submit any issues at <File>https://github.com/gap-packages/kbmag/issues/</File>.<P/>",
         "Acknowledgements": "This documentation was prepared with the &GAPDoc; <Cite Key='GAPDoc'/> and &AutoDoc; <Cite Key='AutoDoc'/> packages.<P/>\nThe procedure used to produce new releases uses the package <Package>GitHubPagesForGAP</Package> <Cite Key='GitHubPagesForGAP' /> and the package <Package>ReleaseTools</Package>.<P/>"
       }
-    },
-    "CommunicatedBy": "Charles Wright (Oregon)",
-    "AcceptDate": "07/2003"
+    }
   },
   "laguna": {
     "Version": "3.9.3",
@@ -9995,7 +9789,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/laguna",
     "IssueTrackerURL": "https://github.com/gap-packages/laguna/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/laguna"
@@ -10007,9 +9800,7 @@
     "ArchiveURL": "https://github.com/gap-packages/laguna/releases/download/v3.9.3/laguna-3.9.3",
     "README_URL": "https://gap-packages.github.io/laguna/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/laguna/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">LAGUNA</span> package replaces the <span class=\"pkgname\">LAG</span> package and provides functionality for calculation of the normalized unit group of the modular group algebra of the finite p-group and for investigation of Lie algebra associated with group algebras and other associative algebras.",
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
-    "AcceptDate": "06/2003"
+    "AbstractHTML": "The <span class=\"pkgname\">LAGUNA</span> package replaces the <span class=\"pkgname\">LAG</span> package and provides functionality for calculation of the normalized unit group of the modular group algebra of the finite p-group and for investigation of Lie algebra associated with group algebras and other associative algebras."
   },
   "liealgdb": {
     "Version": "2.2.1",
@@ -10081,7 +9872,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/liealgdb/",
     "IssueTrackerURL": "https://github.com/gap-packages/liealgdb/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/liealgdb"
@@ -10100,9 +9890,7 @@
         "Abstract": "\nThis package provides access to the classification of the following\nfamilies of Lie algebras:\n<List>\n<Item> non-solvable Lie algebras over finite fields up to dimension 6;\n</Item>\n<Item> nilpotent Lie algebras of dimension up to 9 over <A>GF(2)</A>, of dimension\nup to 7 over <A>GF(3)</A> or <A>GF(5)</A>;</Item>\n<Item> simple Lie algebras of dimensions between 7 and 9 over <A>GF(2)</A>;\n</Item>\n<Item> the classification of solvable Lie algebras of dimension at most 4;\n</Item>\n<Item> the classification of nilpotent Lie algebras of dimensions at most 6.\n</Item>\n</List>\n",
         "Acknowledgements": "\nWe are grateful to Andrea Caranti, Marco Costantini, Bettina Eick,\nHelmut Strade, Michael Vaughan-Lee. Without\ntheir help, interest, and encouragement, this package would not have been\nmade. We also acknowledge the effort of the referees to improve the\nimplementation and the documentation.<P/>\nSerena Cical&#242; would like to thank the Centro de &#193;lgebra da\nUniversidade de Lisboa for their kind hospitality during July - December 2009 and May - September 2010, when the\nclassification of the 6-dimensional nilpotent Lie algebras over\nfields of characteristic 2 was made and added to the package.\n"
       }
-    },
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
-    "AcceptDate": "09/2007"
+    }
   },
   "liepring": {
     "Version": "1.9.2",
@@ -10162,7 +9950,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/liepring/",
     "IssueTrackerURL": "https://github.com/gap-packages/liepring/issues",
     "BannerString": "----------------------------------------------------------------\nLoading  LiePRing 1.9.2\nby Michael Vaughan-Lee and Bettina Eick \n----------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/liepring"
@@ -10173,9 +9960,7 @@
     "ArchiveURL": "https://github.com/gap-packages/liepring/releases/download/v1.9.2/liepring-1.9.2",
     "README_URL": "https://gap-packages.github.io/liepring/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/liepring/PackageInfo.g",
-    "AbstractHTML": "",
-    "CommunicatedBy": "Leonard Soicher (London)",
-    "AcceptDate": "09/2014"
+    "AbstractHTML": ""
   },
   "liering": {
     "Version": "2.4.1",
@@ -10237,7 +10022,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/liering/",
     "IssueTrackerURL": "https://github.com/gap-packages/liering/issues",
     "BannerString": "LieRing\n a package for working with Lie rings \n by Serena Cical\u00f2 and Willem de Graaf\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/liering"
@@ -10256,9 +10040,7 @@
         "Copyright": "&copyright; 2016 Serena Cical\u00f2 and Willem de Graaf",
         "Abstract": "\n            This package provides functions for constructing and working with Lie\n            rings. There are functions for dealing with finitely-presented Lie\n            rings, and for performing the Lazard correspondence. The package also\n            contains a small database of finitely-generated Lie rings satisfying\n            an Engel condition.\n            "
       }
-    },
-    "CommunicatedBy": "Max Neunhoeffer (Cologne)",
-    "AcceptDate": "12/2013"
+    }
   },
   "loops": {
     "Version": "3.4.1",
@@ -10325,7 +10107,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/loops/",
     "IssueTrackerURL": "https://github.com/gap-packages/loops/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/loops"
@@ -10344,9 +10125,7 @@
         "Acknowledgements": "\nWe thank the following people for sending us remarks and comments, and\nfor suggesting new functionality of the package: Muniru Asiru, Bjoern\nAssmann, Andreas Distler, Ale&#353; Dr&#225;pal, Graham Ellis, Steve\nFlammia, Kenneth W. Johnson, Michael K. Kinyon, Olexandr Konovalov,\nFrank L&#252;beck, Jonathan D.H. Smith, David Stanovsk&#253; and Glen\nWhitney.\n\n<P/>The library of Moufang loops of order 243 was generated from data\nprovided by Michael C. Slattery and Ashley L. Zenisek. The library of\nright conjugacy closed loops of order less than 28 was generated from\ndata provided by Katharina Artic. The library of right Bruck loops of\norder 27, 81 was obtained jointly with Izabella Stuhl.\n\n<P/>G\u00e1bor P. Nagy was supported by OTKA grants F042959 and T043758, and\nPetr Vojt\u011bchovsk\u00fd was supported by the 2006 and 2016 University of\nDenver PROF grants and the Simons Foundation Collaboration Grant 210176.\n",
         "Title": "The LOOPS Package"
       }
-    },
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "05/2015"
+    }
   },
   "lpres": {
     "Version": "1.0.1",
@@ -10433,7 +10212,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/lpres",
     "IssueTrackerURL": "https://github.com/gap-packages/lpres/issues",
     "BannerString": "Loading lpres 1.0.1 ...\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/lpres"
@@ -10445,9 +10223,7 @@
     "README_URL": "https://gap-packages.github.io/lpres/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/lpres/PackageInfo.g",
     "AbstractHTML": "The LPRES Package defines new GAP objects to work with L-presented groups, namely groups given by a finite generating set and a possibly-infinite set of relations given as iterates of finitely many seed relations by a finite set of endomorphisms. The package implements nilpotent quotient, Todd-Coxeter and Reidemeister-Schreier algorithms for L-presented groups.",
-    "Autoload": false,
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
-    "AcceptDate": "09/2018"
+    "Autoload": false
   },
   "matgrp": {
     "Version": "0.63",
@@ -10515,7 +10291,6 @@
     "PackageWWWHome": "http://www.math.colostate.edu/~hulpke/matgrp",
     "IssueTrackerURL": "https://github.com/hulpke/matgrp//issues",
     "BannerString": "Matrix Group Interface routines by A. Hulpke\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/hulpke/matgrp/"
@@ -10595,7 +10370,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/modisom/",
     "IssueTrackerURL": "https://github.com/gap-packages/modisom/issues",
     "BannerString": "Loading ModIsom 2.5.1... \n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/modisom"
@@ -10608,9 +10382,7 @@
     "README_URL": "https://gap-packages.github.io/modisom/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/modisom/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">ModIsom</span> package contains various methods for computing with nilpotent associative algebras. In particular, it contains a method to determine the automorphism group and to test isomorphis of such algebras over finite fields and of modular group algebras of finite p-groups, and it contains a nilpotent quotient algorithm for finitely presented associative algebras and a method to determine Kurosh algebras.",
-    "Autoload": false,
-    "CommunicatedBy": "Olexandr Konovalov (St. Andrews)",
-    "AcceptDate": "11/2013"
+    "Autoload": false
   },
   "nilmat": {
     "Version": "1.4",
@@ -10684,7 +10456,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/nilmat",
     "IssueTrackerURL": "https://github.com/gap-packages/nilmat/issues",
     "BannerString": "Loading Nilmat 1.4...\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/nilmat"
@@ -10697,9 +10468,7 @@
     "README_URL": "https://gap-packages.github.io/nilmat/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/nilmat/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">Nilmat</span> package contains methods for checking whether a finitely generated matrix group over a finite field or the field of rational numbers is nilpotent, methods for computing with such nilpotent matrix groups and methods for constructing important classes of such nilpotent matrix groups.",
-    "Autoload": false,
-    "CommunicatedBy": "Derek Holt (Warwick)",
-    "AcceptDate": "08/2007"
+    "Autoload": false
   },
   "nq": {
     "Version": "2.5.4",
@@ -10769,7 +10538,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/nq/",
     "IssueTrackerURL": "https://github.com/gap-packages/nq/issues",
     "BannerString": "Loading nq 2.5.4 (Nilpotent Quotient Algorithm)\n  by Werner Nickel\n  maintained by Max Horn (max.horn@math.uni-giessen.de)\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/nq"
@@ -10790,9 +10558,7 @@
         "Acknowledgements": "            The author of ANU NQ is Werner Nickel.                        <P/>The development of this program was started while the            author was supported by an Australian National University PhD            scholarship and an Overseas Postgraduate Research Scholarship.                        <P/>Further development of this program was done with support from the            DFG-Schwerpunkt-Projekt \"`Algorithmische Zahlentheorie und Algebra\"'.                        <P/>Since then, maintenance of ANU NQ has been taken over by Max Horn. All            credit for creating ANU NQ still goes to Werner Nickel as sole author.            However, bug reports and other  inquiries should be sent to Max  Horn.                        <P/>The following are the original acknowledgements by Werner Nickel.                        <P/>Over the years a number of people have made useful suggestions            that found their way into the code:  Mike Newman, Michael            Vaughan-Lee, Joachim Neub\u00fcser, Charles Sims.                        <P/>Thanks to Volkmar Felsch and Joachim Neub\u00fcser for their careful            examination of the package prior to its release for GAP 4.                        <P/>This documentation was prepared with the <Package>GAPDoc</Package>            package by Frank L\u00fcbeck and Max Neunh\u00f6ffer.",
         "TitleComment": ""
       }
-    },
-    "CommunicatedBy": "Joachim Neub\u00fcser (RWTH Aachen)",
-    "AcceptDate": "01/2003"
+    }
   },
   "orb": {
     "Version": "4.8.3",
@@ -10874,7 +10640,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/orb",
     "IssueTrackerURL": "https://github.com/gap-packages/orb/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/orb"
@@ -10967,7 +10732,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/permut/",
     "IssueTrackerURL": "https://github.com/gap-packages/permut/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/permut"
@@ -10979,9 +10743,7 @@
     "README_URL": "https://gap-packages.github.io/permut/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/permut/PackageInfo.g",
     "AbstractHTML": "This package provides functions for computing with permutability in finite groups.",
-    "SupportEmail": "Ramon.Esteban@uv.es",
-    "CommunicatedBy": "Alice Niemeyer (Perth)",
-    "AcceptDate": "04/2014"
+    "SupportEmail": "Ramon.Esteban@uv.es"
   },
   "polenta": {
     "Version": "1.3.9",
@@ -11054,7 +10816,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/polenta/",
     "IssueTrackerURL": "https://github.com/gap-packages/polenta/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/polenta"
@@ -11073,9 +10834,7 @@
         "Copyright": "            <Index>License</Index>            &copyright; 2003-2007 by Bj\u00f6rn Assmann<P/>            The &Polenta; package is free software;             you can redistribute it and/or modify it under the terms of the             <URL Text=\"GNU General Public License\">http://www.fsf.org/licenses/gpl.html</URL>             as published by the Free Software Foundation; either version 2 of the License,             or (at your option) any later version.",
         "Acknowledgements": "            We appreciate very much all past and future comments, suggestions and             contributions to this package and its documentation provided by &GAP;             users and developers."
       }
-    },
-    "CommunicatedBy": "Charles Wright (Eugene)",
-    "AcceptDate": "08/2005"
+    }
   },
   "polycyclic": {
     "Version": "2.15.1",
@@ -11172,7 +10931,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/polycyclic/",
     "IssueTrackerURL": "https://github.com/gap-packages/polycyclic/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/polycyclic"
@@ -11190,9 +10948,7 @@
         "Copyright": "<Index>License</Index>&copyright; 2003-2018 by Bettina Eick, Max Horn and Werner Nickel<P/>The &Polycyclic; package is free software;you can redistribute it and/or modify it under the terms of the<URL Text=\"GNU General Public License\">http://www.fsf.org/licenses/gpl.html</URL>as published by the Free Software Foundation; either version 2 of the License,or (at your option) any later version.",
         "Acknowledgements": "We appreciate very much all past and future comments, suggestions andcontributions to this package and its documentation provided by &GAP;users and developers."
       }
-    },
-    "CommunicatedBy": "Charles Wright (Eugene)",
-    "AcceptDate": "01/2004"
+    }
   },
   "polymaking": {
     "Version": "0.8.2",
@@ -11249,7 +11005,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/polymaking/",
     "IssueTrackerURL": "https://github.com/gap-packages/polymaking/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/polymaking"
@@ -11347,7 +11102,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/primgrp/",
     "IssueTrackerURL": "https://github.com/gap-packages/primgrp/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/primgrp"
@@ -11408,7 +11162,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/profiling/",
     "IssueTrackerURL": "https://github.com/gap-packages/profiling/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/profiling"
@@ -11480,7 +11233,6 @@
     ],
     "PackageWWWHome": "https://folk.ntnu.no/oyvinso/QPA/",
     "IssueTrackerURL": "https://github.com/gap-packages/qpa/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/qpa"
@@ -11544,7 +11296,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/quagroup/",
     "IssueTrackerURL": "https://github.com/gap-packages/quagroup/issues",
     "BannerString": "     |                                                                 \n     |          QuaGroup 1.8.2\n     |                                                                 \n-----------     A package for dealing with quantized enveloping algebras\n     |                                                                 \n     |          Willem de Graaf                                        \n     |          degraaf@science.unitn.it                               \n\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/quagroup"
@@ -11562,9 +11313,7 @@
         "Version": "Version 1.8.2",
         "Copyright": "&copyright; 2002 Willem A. de Graaf"
       }
-    },
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
-    "AcceptDate": "10/2003"
+    }
   },
   "radiroot": {
     "Version": "2.8",
@@ -11620,7 +11369,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/radiroot/",
     "IssueTrackerURL": "https://github.com/gap-packages/radiroot/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/radiroot"
@@ -11632,9 +11380,7 @@
     "README_URL": "https://gap-packages.github.io/radiroot/README",
     "PackageInfoURL": "https://gap-packages.github.io/radiroot/PackageInfo.g",
     "AbstractHTML": "The <span class=\"pkgname\">RadiRoot</span> package installs a method to    display the roots of a rational polynomial as radicals if it is solvable.",
-    "Autoload": false,
-    "CommunicatedBy": "Edmund Robertson (St Andrews)",
-    "AcceptDate": "02/2007"
+    "Autoload": false
   },
   "rcwa": {
     "Version": "4.6.4",
@@ -11707,7 +11453,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/rcwa/",
     "IssueTrackerURL": "https://github.com/gap-packages/rcwa/issues",
     "BannerString": "\nLoading RCWA 4.6.4 ([R]esidue-[C]lass-[W]ise [A]ffine groups)\n  by Stefan Kohl, stefan@mcs.st-and.ac.uk.\nSee ?RCWA:About for information about the package.\n\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/rcwa"
@@ -11726,9 +11471,7 @@
         "Abstract": "<#Include SYSTEM \"abstract.xml\">",
         "Acknowledgements": "\nI am grateful to John P. McDermott for the discovery that the group\ndiscussed in Section&nbsp;<Ref Label=\"sec:ThompsonsGroupV\"/> is\nisomorphic to Thompson's Group V in July 2008, and to Laurent Bartholdi\nfor his hint on how to construct wreath products of residue-class-wise\naffine groups with&nbsp;(&ZZ;,+) in April 2006.\nFurther, I thank Bettina&nbsp;Eick for communicating this package\nand for her valuable suggestions on its manual in the time before its\nfirst public release in April 2005.\nLast but not least I thank the two anonymous referees for their\nconstructive criticism and their helpful suggestions.\n        "
       }
-    },
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
-    "AcceptDate": "04/2005"
+    }
   },
   "rds": {
     "Version": "1.7",
@@ -11789,7 +11532,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/rds/",
     "IssueTrackerURL": "https://github.com/gap-packages/rds/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/rds"
@@ -11801,9 +11543,7 @@
     "ArchiveURL": "https://github.com/gap-packages/rds/releases/download/v1.7/rds-1.7",
     "README_URL": "https://gap-packages.github.io/rds/README.rds",
     "PackageInfoURL": "https://gap-packages.github.io/rds/PackageInfo.g",
-    "AbstractHTML": "This package provides functions for the complete enumeration of relative difference sets.",
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
-    "AcceptDate": "02/2008"
+    "AbstractHTML": "This package provides functions for the complete enumeration of relative difference sets."
   },
   "recog": {
     "Version": "1.3.2",
@@ -11987,7 +11727,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/recog",
     "IssueTrackerURL": "https://github.com/gap-packages/recog/issues",
     "BannerString": "-----------------------------------------------------------------------------\nLoading  recog 1.3.2 - methods for constructive recognition\n\nby Max Neunh\u00f6ffer (http://www-groups.mcs.st-and.ac.uk/~neunhoef) and\n   \u00c1kos Seress\nwith contributed code by:\n     Nurullah Ankaralioglu,\n     Peter Brooksbank (http://www.facstaff.bucknell.edu/pbrooksb/),\n     Frank Celler (http://www.celler.de/),\n     Stephen Howe,\n     Maska Law,\n     Steve Linton (http://www-circa.mcs.st-and.ac.uk/~sal/),\n     Gunter Malle (http://www.mathematik.uni-kl.de/~malle/),\n     Alice Niemeyer (http://www.maths.uwa.edu.au/~alice/),\n     Eamonn O'Brien (http://www.math.auckland.ac.nz/~obrien/),\n     Colva M. Roney-Dougal (http://www-groups.mcs.st-and.ac.uk/~colva),\n and Max Horn (https://www.quendi.de/math).\n-----------------------------------------------------------------------------\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/recog"
@@ -12057,7 +11796,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/repsn/",
     "IssueTrackerURL": "https://github.com/gap-packages/repsn/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/repsn"
@@ -12074,9 +11812,7 @@
       "TitlePage": {
         "Acknowledgements": "\n<P/>The first version of this package was obtained during my Ph.D.\nstudies at Carleton University. I would like to express deep gratitude\nto my supervisor Professor John D. Dixon whose guidance and support were\ncrucial for the successful completion of this project. I also thank\nProfessor Charles Wright and referees for pointing out some important\ncomments to improve <Package>Repsn</Package>.\n\n<P/>This documentation was prepared with the <Package>GAPDoc</Package>\npackage by Frank L\u00fcbeck and Max Neunh\u00f6ffer.\n"
       }
-    },
-    "CommunicatedBy": "Charles Wright (Eugene)",
-    "AcceptDate": "05/2004"
+    }
   },
   "resclasses": {
     "Version": "4.7.2",
@@ -12138,7 +11874,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/resclasses/",
     "IssueTrackerURL": "https://github.com/gap-packages/resclasses/issues",
     "BannerString": "\nLoading ResClasses 4.7.2 (Computations with Residue Classes)\nby Stefan Kohl, stefan@mcs.st-and.ac.uk\n\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/resclasses"
@@ -12391,7 +12126,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/Semigroups",
     "IssueTrackerURL": "https://github.com/gap-packages/Semigroups/issues",
     "BannerString": "-----------------------------------------------------------------------------\nLoading  Semigroups 3.2.3\nby James Mitchell (http://www-groups.mcs.st-andrews.ac.uk/~jamesm/)\nwith contributions by:\n     Stuart Burrell (http://sburrell.nfshost.com),\n     Manuel Delgado (http://cmup.fc.up.pt/cmup/mdelgado/),\n     James East (http://goo.gl/MuiJu5),\n     Attila Egri-Nagy (http://www.egri-nagy.hu),\n     Nicholas Ham (https://n-ham.github.io),\n     Max Horn (https://www.quendi.de/math),\n     Julius Jonusas (http://julius.jonusas.work),\n     Dima V. Pasechnik (http://users.ox.ac.uk/~coml0531/),\n     Markus Pfeiffer (https://www.morphism.de/~markusp/),\n     Christopher Russell,\n     Benjamin Steinberg (http://www.sci.ccny.cuny.edu/~benjamin/),\n     Finn Smith,\n     Jhevon Smith (http://math.sci.ccny.cuny.edu/people?name=Jhevon_Smith),\n     Michael Torpey (https://mtorpey.github.io),\n     Murray Whyte,\n and Wilf Wilson (http://wilf.me).\n-----------------------------------------------------------------------------\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/Semigroups"
@@ -12468,7 +12202,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/sglppow/",
     "IssueTrackerURL": "https://github.com/gap-packages/sglppow/issues",
     "BannerString": "----------------------------------------------------------------\nLoading SglPPow 2.1\nby Michael Vaughan-Lee and Bettina Eick \n----------------------------------------------------------------\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/sglppow"
@@ -12479,9 +12212,7 @@
     "ArchiveURL": "https://github.com/gap-packages/sglppow/releases/download/v2.1/sglppow-2.1",
     "README_URL": "https://gap-packages.github.io/sglppow/README",
     "PackageInfoURL": "https://gap-packages.github.io/sglppow/PackageInfo.g",
-    "AbstractHTML": "",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "08/2016"
+    "AbstractHTML": ""
   },
   "simpcomp": {
     "Version": "2.1.10",
@@ -12579,7 +12310,6 @@
     "PackageWWWHome": "https://simpcomp-team.github.io/simpcomp/",
     "IssueTrackerURL": "https://github.com/simpcomp-team/simpcomp/issues",
     "BannerString": "Loading simpcomp 2.1.10\nby F. Effenberger and J. Spreer\nhttps://github.com/simpcomp-team/simpcomp\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/simpcomp-team/simpcomp"
@@ -12591,9 +12321,7 @@
     "README_URL": "https://simpcomp-team.github.io/simpcomp/README.md",
     "PackageInfoURL": "https://simpcomp-team.github.io/simpcomp/PackageInfo.g",
     "AbstractHTML": "<span class=\"pkgname\">simpcomp</span> is a <span class=\"pkgname\">GAP</span> package for working with simplicial complexes. It allows the computation of many properties of simplicial complexes (such as the f-, g- and h-vectors, the face lattice, the automorphism group, (co-)homology with explicit basis computation, intersection form, etc.) and provides the user with functions to compute new complexes from old (simplex links and stars, connected sums, cartesian products, handle additions, bistellar flips, etc.). Furthermore, it comes with an extensive library of known triangulations of manifolds and provides the user with the possibility to create own complex libraries.<br /> <span class=\"pkgname\">simpcomp</span> caches computed properties of a simplicial complex, thus avoiding unnecessary computations, internally handles the vertex labeling of the complexes and insures the consistency of a simplicial complex throughout all operations.<br /> <span class=\"pkgname\">simpcomp</span> relies on the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">homology</span> for its homology computation, but also provides the user with an own (co-)homology algorithm in case the packacke <span class=\"pkgname\">homology</span> is not available. For automorphism group computation the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">GRAPE</span> is used, which in turn uses the program <tt>nauty</tt> by Brendan McKay. An internal automorphism group calculation algorithm in used as fallback if the <span class=\"pkgname\">GRAPE</span> package is not available.",
-    "Autoload": false,
-    "CommunicatedBy": "Graham Ellis (Galway)",
-    "AcceptDate": "11/2013"
+    "Autoload": false
   },
   "singular": {
     "Version": "2019.10.01",
@@ -12656,7 +12384,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/singular/",
     "IssueTrackerURL": "https://github.com/gap-packages/singular/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/singular"
@@ -12725,7 +12452,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/sla/",
     "IssueTrackerURL": "https://github.com/gap-packages/sla/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/sla"
@@ -12744,9 +12470,7 @@
         "Copyright": "&copyright; 2013-2018 Willem de Graaf",
         "Abstract": "\n            This package provides functions for computing with various\n            aspects of the theory of simple Lie algebras in characteristic\n            zero.\n            "
       }
-    },
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
-    "AcceptDate": "01/2016"
+    }
   },
   "smallsemi": {
     "Version": "0.6.12",
@@ -12805,7 +12529,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/smallsemi/",
     "IssueTrackerURL": "https://github.com/gap-packages/smallsemi/issues",
     "BannerString": "-----------------------------------------------------------------------------------------------\nSmallsemi -   A library of small semigroups\nby Andreas Distler & James Mitchell\nFor contents, type: ?Smallsemi:\nLoading Smallsemi 0.6.12 ...\n-----------------------------------------------------------------------------------------------\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/smallsemi"
@@ -12934,7 +12657,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/sonata/",
     "IssueTrackerURL": "https://github.com/gap-packages/sonata/issues",
     "BannerString": "\n  ___________________________________________________________________________\n /        ___\n||       /   \\                 /\\    Version 2.9.1\n||      ||   ||  |\\    |      /  \\               /\\       Erhard Aichinger\n \\___   ||   ||  |\\\\   |     /____\\_____________/__\\      Franz Binder\n     \\  ||   ||  | \\\\  |    /      \\     ||    /    \\     Juergen Ecker\n     ||  \\___/   |  \\\\ |   /        \\    ||   /      \\    Peter Mayr\n     ||          |   \\\\|  /          \\   ||               Christof Noebauer\n \\___/           |    \\|                 ||\n\n System    Of   Nearrings     And      Their Applications\n Info: https://gap-packages.github.io/sonata/\n\n",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/sonata"
@@ -12945,9 +12667,7 @@
     "ArchiveURL": "https://github.com/gap-packages/sonata/releases/download/v2.9.1/sonata-2.9.1",
     "README_URL": "https://gap-packages.github.io/sonata/README",
     "PackageInfoURL": "https://gap-packages.github.io/sonata/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">SONATA</span> package provides methods for     the construction and analysis of finite nearrings.",
-    "CommunicatedBy": "Charles R.B. Wright (Univ. of Oregon)",
-    "AcceptDate": "04/2003"
+    "AbstractHTML": "The <span class=\"pkgname\">SONATA</span> package provides methods for     the construction and analysis of finite nearrings."
   },
   "sophus": {
     "Version": "1.24",
@@ -13003,7 +12723,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/sophus/",
     "IssueTrackerURL": "https://github.com/gap-packages/sophus/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/sophus"
@@ -13021,9 +12740,7 @@
         "Abstract": "\n&Sophus; is a GAP4 package to compute with nilpotent\nLie algebras over finite prime fields. In particular, the package can be\nused to compute certain central extensions and the automorphism group\nof such Lie algebras. &Sophus; also enables its user to test\nisomorphism between two nilpotent Lie algebras. The author of the\npackage used it to construct all Lie algebras of dimension at most 9\nover <Math>\\mathbb F_2</Math>.\n",
         "Acknowledgements": "\nMost of the work on this package was carried out while I held a\nresearch position at the Technische Universit\u00e4t Braunschweig. I\nwould like to express my gratitude to the staff and the students of\nthe Institut f\u00fcr Geometrie for their interest in this work. Special\nthanks go to Bettina Eick for her r\u00f4le in completing this project.\n"
       }
-    },
-    "CommunicatedBy": "Olexandr Konovalov (Zaporozhye)",
-    "AcceptDate": "10/2004"
+    }
   },
   "spinsym": {
     "Version": "1.5.2",
@@ -13085,7 +12802,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/spinsym/",
     "IssueTrackerURL": "https://github.com/gap-packages/spinsym/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/spinsym"
@@ -13176,7 +12892,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/tomlib",
     "IssueTrackerURL": "https://github.com/gap-packages/tomlib/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/tomlib"
@@ -13236,7 +12951,6 @@
       }
     ],
     "PackageWWWHome": "https://www.math.colostate.edu/~hulpke/transgrp",
-    "Status": "deposited",
     "Subtitle": "Transitive Groups Library",
     "TestFile": "tst/testall.g",
     "ArchiveFormats": ".tar.gz",
@@ -13298,7 +13012,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/unipot/",
     "IssueTrackerURL": "https://github.com/gap-packages/unipot/issues",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/unipot"
@@ -13383,7 +13096,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/unitlib",
     "IssueTrackerURL": "https://github.com/gap-packages/unitlib/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/unitlib"
@@ -13394,9 +13106,7 @@
     "ArchiveURL": "https://github.com/gap-packages/unitlib/releases/download/v4.0.0/unitlib-4.0.0",
     "README_URL": "https://gap-packages.github.io/unitlib/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/unitlib/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">UnitLib</span> package extends the <span class=\"pkgname\">LAGUNA</span> package and provides the library of normalized unit groups of modular group algebras of all finite p-groups of order less than 243 over the field of p elements.",
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
-    "AcceptDate": "03/2007"
+    "AbstractHTML": "The <span class=\"pkgname\">UnitLib</span> package extends the <span class=\"pkgname\">LAGUNA</span> package and provides the library of normalized unit groups of modular group algebras of all finite p-groups of order less than 243 over the field of p elements."
   },
   "utils": {
     "Version": "0.69",
@@ -13493,7 +13203,6 @@
     "PackageWWWHome": "https://gap-packages.github.io/utils",
     "IssueTrackerURL": "https://github.com/gap-packages/utils/issues",
     "BannerString": "Loading Utils 0.69 for GAP 4.10 - a collection of utility functions.\n",
-    "Status": "deposited",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/utils"
@@ -13562,7 +13271,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/uuid/",
     "IssueTrackerURL": "https://github.com/gap-packages/uuid/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/uuid"
@@ -13641,7 +13349,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/walrus",
     "IssueTrackerURL": "https://github.com/gap-packages/walrus/issues",
-    "Status": "dev",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/walrus"
@@ -13797,7 +13504,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/wedderga",
     "IssueTrackerURL": "https://github.com/gap-packages/wedderga/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/wedderga"
@@ -13808,9 +13514,7 @@
     "ArchiveURL": "https://github.com/gap-packages/wedderga/releases/download/v4.9.5/wedderga-4.9.5",
     "README_URL": "https://gap-packages.github.io/wedderga/README.md",
     "PackageInfoURL": "https://gap-packages.github.io/wedderga/PackageInfo.g",
-    "AbstractHTML": "<span class=\"pkgname\">Wedderga</span> is the package to compute the simple components of the Wedderburn decomposition of semisimple group algebras of finite groups over finite fields and over subfields of finite cyclotomic extensions of the rationals. It also contains functions that produce the primitive central idempotents of semisimple group algebras and functions for computing Schur indices. Other functions of <span class=\"pkgname\">Wedderga</span> allow one to construct crossed products over a group with coefficients in an associative ring with identity and the multiplication determined by a given action and twisting.",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
-    "AcceptDate": "01/2008"
+    "AbstractHTML": "<span class=\"pkgname\">Wedderga</span> is the package to compute the simple components of the Wedderburn decomposition of semisimple group algebras of finite groups over finite fields and over subfields of finite cyclotomic extensions of the rationals. It also contains functions that produce the primitive central idempotents of semisimple group algebras and functions for computing Schur indices. Other functions of <span class=\"pkgname\">Wedderga</span> allow one to construct crossed products over a group with coefficients in an associative ring with identity and the multiplication determined by a given action and twisting."
   },
   "xgap": {
     "Version": "4.30",
@@ -13869,7 +13573,6 @@
     ],
     "PackageWWWHome": "https://gap-packages.github.io/xgap",
     "IssueTrackerURL": "https://github.com/gap-packages/xgap/issues",
-    "Status": "accepted",
     "SourceRepository": {
       "Type": "git",
       "URL": "https://github.com/gap-packages/xgap"
@@ -13880,8 +13583,6 @@
     "ArchiveURL": "https://github.com/gap-packages/xgap/releases/download/v4.30/xgap-4.30",
     "README_URL": "https://gap-packages.github.io/xgap/README",
     "PackageInfoURL": "https://gap-packages.github.io/xgap/PackageInfo.g",
-    "AbstractHTML": "The <span class=\"pkgname\">XGAP</span> package allows to use graphics in GAP.",
-    "CommunicatedBy": "Gerhard Hi\u00df (Aachen)",
-    "AcceptDate": "07/1999"
+    "AbstractHTML": "The <span class=\"pkgname\">XGAP</span> package allows to use graphics in GAP."
   }
 }

--- a/_data/package-infos/4-11-1.json
+++ b/_data/package-infos/4-11-1.json
@@ -65,18 +65,15 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A link to 4ti2",
     "Version": "2020.10-02"
   },
   "ace": {
     "AbstractHTML": "The <span class=\"pkgname\">ACE</span> package provides both an    interactive and non-interactive interface with the Todd-Coxeter coset   enumeration functions of the ACE (Advanced Coset Enumerator) C program.",
-    "AcceptDate": "04/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/ace/releases/download/v5.3/ace-5.3",
     "AvailabilityTest": null,
     "BannerString": "---------------------------------------------------------------------------\nLoading    ACE (Advanced Coset Enumerator) 5.3\nGAP code by Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)\n       Alexander Hulpke (https://www.math.colostate.edu/~hulpke)\n           [uses ACE binary (C code program) version: 3.001]\nC code by  George Havas (http://staff.itee.uq.edu.au/havas)\n           Colin Ramsay <cram@itee.uq.edu.au>\nCo-maintainer: Max Horn <max.horn@uni-siegen.de>\n\n                 For help, type: ?ACE\n---------------------------------------------------------------------------\n",
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "12/02/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -174,18 +171,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ace"
     },
-    "Status": "accepted",
     "Subtitle": "Advanced Coset Enumerator",
     "TestFile": "tst/aceds.tst",
     "Version": "5.3"
   },
   "aclib": {
     "AbstractHTML": "The <span class=\"pkgname\">AClib</span> package contains a library of almost crystallographic groups and a some algorithms to compute with these groups. A group is called almost crystallographic if it is finitely generated nilpotent-by-finite and has no non-trivial finite normal subgroups. Further, an almost crystallographic group is called almost Bieberbach if it is torsion-free. The almost crystallographic groups of Hirsch length 3 and a part of the almost cyrstallographic groups of Hirsch length 4 have been classified by Dekimpe. This classification includes all almost Bieberbach groups of Hirsch lengths 3 or 4. The AClib package gives access to this classification; that is, the package contains this library of groups in a computationally useful form. The groups in this library are available in two different representations. First, each of the groups of Hirsch length 3 or 4 has a rational matrix representation of dimension 4 or 5, respectively, and such representations are available in this package. Secondly, all the groups in this libraray are (infinite) polycyclic groups and the package also incorporates polycyclic presentations for them. The polycyclic presentations can be used to compute with the given groups using the methods of the Polycyclic package.",
-    "AcceptDate": "02/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/aclib/releases/download/v1.3.2/aclib-1.3.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -259,7 +253,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/aclib"
     },
-    "Status": "accepted",
     "Subtitle": "Almost Crystallographic Groups - A Library and Algorithms",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
@@ -337,7 +330,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/AGT"
     },
-    "Status": "other",
     "Subtitle": "Algebraic Graph Theory",
     "SupportEmail": "r.evans@qmul.ac.uk",
     "TestFile": "tst/testall.g",
@@ -345,11 +337,9 @@
   },
   "alnuth": {
     "AbstractHTML": "The <span class=\"pkgname\">Alnuth</span> package provides various methods to compute with number fields which are given by a defining polynomial or by generators. Some of the methods provided in this package are written in <span class=\"pkgname\">GAP</span> code. The other part of the methods is imported from the computer algebra system PARI/GP. Hence this package contains some <span class=\"pkgname\">GAP</span> functions and an interface to some functions in the computer algebra system PARI/GP. The main methods included in <span class=\"pkgname\">Alnuth</span> are: creating a number field, computing its maximal order (using PARI/GP), computing its unit group (using PARI/GP) and a presentation of this unit group, computing the elements of a given norm of the number field (using PARI/GP), determining a presentation for a finitely generated multiplicative subgroup (using PARI/GP), and factoring polynomials defined over number fields (using PARI/GP).",
-    "AcceptDate": "01/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/alnuth/releases/download/v3.1.2/alnuth-3.1.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [
@@ -426,20 +416,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/alnuth"
     },
-    "Status": "accepted",
     "Subtitle": "Algebraic number theory and an interface to PARI/GP",
     "TestFile": "tst/testall.g",
     "Version": "3.1.2"
   },
   "anupq": {
     "AbstractHTML": "The <span class=\"pkgname\">ANUPQ</span> package provides an interactive    interface to the p-quotient, p-group generation and standard presentation    algorithms of the ANU pq C program.",
-    "AcceptDate": "04/2002",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/anupq/releases/download/v3.2.1/anupq-3.2.1",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "---------------------------------------------------------------------------\nLoading    ANUPQ (ANU p-Quotient) 3.2.1\nGAP code by  Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)\n           Werner Nickel (http://www.mathematik.tu-darmstadt.de/~nickel/)\n           [uses ANU pq binary (C code program) version: 1.9]\nC code by  Eamonn O'Brien (https://www.math.auckland.ac.nz/~obrien)\nCo-maintained by Max Horn <max.horn@uni-siegen.de>\n\n            For help, type: ?ANUPQ\n---------------------------------------------------------------------------\n",
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "18/04/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -524,18 +511,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/anupq"
     },
-    "Status": "accepted",
     "Subtitle": "ANU p-Quotient",
     "TestFile": "tst/testinstall.g",
     "Version": "3.2.1"
   },
   "atlasrep": {
     "AbstractHTML": "The package provides a <span class=\"pkgname\">GAP</span> interface to the <a href=\"http://brauer.maths.qmul.ac.uk/Atlas/v3\">Atlas of Group Representations</a>",
-    "AcceptDate": "04/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/atlasrep-2r1p0",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "10/05/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -645,7 +629,6 @@
       }
     ],
     "README_URL": "http://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/README.md",
-    "Status": "accepted",
     "Subtitle": "A GAP Interface to the Atlas of Group Representations",
     "TestFile": "tst/testauto.g",
     "Version": "2.1.0"
@@ -761,19 +744,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/AutoDoc"
     },
-    "Status": "deposited",
     "Subtitle": "Generate documentation from GAP source code",
     "TestFile": "tst/testall.g",
     "Version": "2020.08.11"
   },
   "automata": {
     "AbstractHTML": "The <span class=\"pkgname\">Automata</span> package, as its name suggests, is package with algorithms to deal with automata.",
-    "AcceptDate": "09/2004",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/automata/releases/download/v1.14/automata-1.14",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
     "Date": "26/09/2018",
     "Dependencies": {
       "GAP": ">=4.8",
@@ -842,20 +822,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/automata"
     },
-    "Status": "accepted",
     "Subtitle": "A package on automata",
     "TestFile": "tst/testall.g",
     "Version": "1.14"
   },
   "automgrp": {
     "AbstractHTML": "The <span class=\"pkgname\">AutomGrp</span> package provides methods for computations with groups and semigroups generated by finite automata or given by wreath recursion, as well as with their finitely generated subgroups and elements.",
-    "AcceptDate": "03/2016",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/automgrp/releases/download/v1.3.2/automgrp-1.3.2",
     "Autoload": true,
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\n     ^                                    ___                   \n    / \\                                  /   \\                  \n   /   \\           _______  ___         ||        ___   __      \n  /_____\\   ||  ||    |    /   \\  |\\ /| ||   __ |/   | |  \\    \n /       \\  ||  ||    |   ||   || | V | ||   || |      |__/    \n/         \\  \\__/     |    \\___/  |   |  \\___/  |      |        \n                                                                \nLoading  AutomGrp 1.3.2 (Automata Groups and Semigroups)\nby Yevgen Muntyan (muntyan@fastmail.fm)\n   Dmytro Savchuk (http://savchuk.myweb.usf.edu/)\nHomepage: https://gap-packages.github.io/automgrp\n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
     "Date": "30/09/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -927,18 +904,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/automgrp"
     },
-    "Status": "accepted",
     "Subtitle": "Automata groups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
   },
   "autpgrp": {
     "AbstractHTML": "The <span class=\"pkgname\">AutPGrp</span> package introduces a new function to compute the automorphism group of a finite $p$-group. The underlying algorithm is a refinement of the methods described in O'Brien (1995). In particular, this implementation is more efficient in both time and space requirements and hence has a wider range of applications than the ANUPQ method. Our package is written in GAP code and it makes use of a number of methods from the GAP library such as the MeatAxe for matrix groups and permutation group functions. We have compared our method to the others available in GAP. Our package usually out-performs all but the method designed for finite abelian groups. We note that our method uses the small groups library in certain cases and hence our algorithm is more effective if the small groups library is installed.",
-    "AcceptDate": "09/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/autpgrp/releases/download/v1.10.2/autpgrp-1.10.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Derek F. Holt (Warwick)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1010,7 +984,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/autpgrp"
     },
-    "Status": "accepted",
     "Subtitle": "Computing the Automorphism Group of a p-Group",
     "TestFile": "tst/testall.g",
     "Version": "1.10.2"
@@ -1091,7 +1064,6 @@
       }
     ],
     "README_URL": "http://www.math.rwth-aachen.de/~Browse/README",
-    "Status": "deposited",
     "Subtitle": "browsing applications and ncurses interface",
     "Version": "1.8.11"
   },
@@ -1188,13 +1160,11 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Categories, Algorithms, Programming",
     "Version": "2020.10-01"
   },
   "caratinterface": {
     "AbstractHTML": "This package provides <span class=\"pkgname\">GAP</span> interface routines to some of the stand-alone programs of <a href=\"https://lbfm-rwth.github.io/carat\">CARAT</a>, a package for the computation with crystallographic groups. CARAT is to a large extent complementary to the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">Cryst</span>. In particular, it provides routines for the computation of normalizers and conjugators of finite unimodular groups in GL(n,Z), and routines for the computation of Bravais groups, which are all missing in <span class=\"pkgname\">Cryst</span>. A catalog of Bravais groups up to dimension 6 is also provided.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CaratInterface/CaratInterface-2.3.3",
     "AvailabilityTest": null,
@@ -1203,7 +1173,6 @@
       "doc/manual.dvi",
       "carat.tgz"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "20/12/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1257,7 +1226,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/caratinterface"
     },
-    "Status": "accepted",
     "Subtitle": "Interface to CARAT, a crystallographic groups package",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -1322,18 +1290,15 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CddInterface"
     },
-    "Status": "deposited",
     "Subtitle": "Gap interface to Cdd package",
     "TestFile": "tst/testall.g",
     "Version": "2020.06.24"
   },
   "circle": {
     "AbstractHTML": "The <span class=\"pkgname\">Circle</span> package provides functionality for computations in adjoint groups of finite associative rings. It allows to construct circle objects that will respect the circle multiplication r*s=r+s+rs, create multiplicative groups, generated by such objects, and compute groups of elements, invertible with respect to this operation. Also it may serve as an example of extending the GAP system with new multiplicative objects.",
-    "AcceptDate": "01/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/circle/releases/download/v1.6.3/circle-1.6.3",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "01/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1400,19 +1365,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/circle"
     },
-    "Status": "accepted",
     "Subtitle": "Adjoint groups of finite rings",
     "TestFile": "tst/testall.g",
     "Version": "1.6.3"
   },
   "cohomolo": {
     "AbstractHTML": "The <span class=\"pkgname\">cohomolo</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for computing Schur multipliers and covering groups of finite groups   and first and second cohomology groups of finite groups acting   on finite modules",
-    "AcceptDate": "01/1970",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/cohomolo/releases/download/v1.6.8/cohomolo-1.6.8",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "unknown (unknown)",
     "Date": "07/07/2019",
     "Dependencies": {
       "ExternalConditions": [
@@ -1470,18 +1432,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cohomolo"
     },
-    "Status": "accepted",
     "Subtitle": "Cohomology groups of finite groups on finite modules",
     "TestFile": "tst/testall.g",
     "Version": "1.6.8"
   },
   "congruence": {
     "AbstractHTML": "The <span class=\"pkgname\">Congruence </span> package provides functions to construct several types of canonical congruence subgroups in SL_2(Z), and also intersections of a finite number of such subgroups. Furthermore, it implements the algorithm for generating Farey symbols for congruence subgroups and using them to produce a system of independent generators for these subgroups",
-    "AcceptDate": "09/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/congruence/releases/download/v1.2.3/congruence-1.2.3",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Graham Ellis (Galway)",
     "Date": "19/05/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1568,14 +1527,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/congruence"
     },
-    "Status": "accepted",
     "Subtitle": "Congruence subgroups of SL(2,Integers)",
     "TestFile": "tst/testall.g",
     "Version": "1.2.3"
   },
   "corelg": {
     "AbstractHTML": "The package <span class=\"pkgname\">CoReLG</span> contains functionality for working with real semisimple Lie algebras.",
-    "AcceptDate": "01/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/corelg/releases/download/v1.54/corelg-1.54",
     "AutoDoc": {
@@ -1588,7 +1545,6 @@
     },
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "17/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1663,13 +1619,11 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/corelg"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with real Lie algebras",
     "Version": "1.54"
   },
   "crime": {
     "AbstractHTML": "This package computes the cohomology rings of finite p-groups, induced maps, and Massey products.",
-    "AcceptDate": "10/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/crime/releases/download/v1.5/crime-1.5",
     "AutoDoc": {
@@ -1681,7 +1635,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\nThis is CRIME, Version 1.5\n\"Obviously crime pays, or there'd be no crime\".\n                                G. Gordon Liddy\n\n",
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "11/10/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1732,14 +1685,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crime"
     },
-    "Status": "accepted",
     "Subtitle": "A GAP Package to Calculate Group Cohomology and Massey Products",
     "TestFile": "tst/testall.g",
     "Version": "1.5"
   },
   "crisp": {
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">CRISP</span> provides algorithms for computing subgroups of finite soluble groups related to a group class <i>C</i>. In particular, it allows to compute <i>C</i>-radicals and <i>C</i>-injectors for Fitting classes (and Fitting sets) <i>C</i>, <i>C</i>-residuals for formations <i>C</i>, and <i>C</i>-projectors for Schunck classes <i>C</i>. In order to carry out these computations, the group class <i>C</i> must be represented by an algorithm which can decide membership in the group class.</p>  <p>Moreover, <span class=\"pkgname\">CRISP</span> contains algorithms for the computation of normal subgroups invariant under a prescribed set of automorphisms and belonging to a given group class.</p>  <p>This includes an improved method to compute the set of all normal subgroups of a finite soluble group, its characteristic subgroups, minimal normal subgroups and the socle and <i>p</i>-socles for given primes <i>p</i>.",
-    "AcceptDate": "12/2000",
     "ArchiveFormats": ".tar.bz2",
     "ArchiveURL": "http://www.icm.tu-bs.de/~bhoeflin/crisp/crisp-1.4.5",
     "Autoload": true,
@@ -1748,7 +1699,6 @@
     "BinaryFiles": [
       "doc/manual.pdf"
     ],
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "07/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1804,7 +1754,6 @@
       "Type": "git",
       "URL": "https://github.com/bh11/crisp.git"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with Radicals, Injectors, Schunck classes and Projectors",
     "TestFile": "tst/testall.g",
     "Version": "1.4.5"
@@ -1868,14 +1817,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crypting"
     },
-    "Status": "deposited",
     "Subtitle": "Hashes and Crypto in GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.10"
   },
   "cryst": {
     "AbstractHTML": "This package, previously known as <span class=\"pkgname\">CrystGAP</span>, provides a rich set of methods for the computation with affine crystallographic groups, in particular space groups. Affine crystallographic groups are fully supported both in representations acting from the right or from the left, the latter one being preferred by crystallographers. Functions to determine representatives of all space group types of a given dimension are also provided. Where necessary, <span class=\"pkgname\">Cryst</span> can also make use of functionality provided by the package <span class=\"pkgname\">CaratInterface</span>.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/Cryst/cryst-4.1.23",
     "AvailabilityTest": null,
@@ -1883,7 +1830,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "10/12/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1978,7 +1924,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cryst"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with crystallographic groups",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -1986,7 +1931,6 @@
   },
   "crystcat": {
     "AbstractHTML": "This package provides a catalog of crystallographic groups of dimensions 2, 3, and 4 which covers most of the data contained in the book <em>Crystallographic groups of four-dimensional space</em> by H. Brown, R. B&uuml;low, J. Neub&uuml;ser, H. Wondratschek, and H. Zassenhaus (John Wiley, New York, 1978). Methods for the computation with these groups are provided by the package <span class=\"pkgname\">Cryst</span>, which must be installed as well.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap45/CrystCat/crystcat-1.1.9",
     "AvailabilityTest": null,
@@ -1994,7 +1938,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "28/05/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2058,7 +2001,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crystcat"
     },
-    "Status": "accepted",
     "Subtitle": "The crystallographic groups catalog",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -2171,19 +2113,16 @@
       }
     ],
     "README_URL": "http://www.math.rwth-aachen.de/~Thomas.Breuer/ctbllib/README.md",
-    "Status": "deposited",
     "Subtitle": "The GAP Character Table Library",
     "TestFile": "tst/testauto.g",
     "Version": "1.3.1"
   },
   "cubefree": {
     "AbstractHTML": "The <span class=\"pkgname\">Cubefree</span> package contains methods to construct up to isomorphism the groups of a given (reasonable) cubefree order. The main function ConstructAllCFGroups(n) constructs all groups of a given cubefree order n. The function NumberCFGroups(n) counts all groups of a cubefree order n. Furthermore, IrreducibleSubgroupsOfGL(2,q) constructs the irreducible subgroups of GL(2,q), q=p^r, p>=5 prime, up to conjugacy and RewriteAbsolutelyIrreducibleMatrixGroup(G) rewrites the absolutely irreducible matrix group G (over a finite field) over a minimal subfield.",
-    "AcceptDate": "10/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/cubefree/releases/download/v1.18/cubefree-1.18",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "30/09/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2243,7 +2182,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cubefree"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing the Groups of a Given Cubefree Order",
     "TestFile": "tst/testall.g",
     "Version": "1.18"
@@ -2312,7 +2250,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/curlInterface"
     },
-    "Status": "deposited",
     "Subtitle": "Simple Web Access",
     "TestFile": "tst/testall.g",
     "Version": "2.2.1"
@@ -2393,7 +2330,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cvec"
     },
-    "Status": "deposited",
     "Subtitle": "Compact vectors over finite fields",
     "TestFile": "tst/testall.g",
     "Version": "2.7.4"
@@ -2494,7 +2430,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/datastructures"
     },
-    "Status": "dev",
     "Subtitle": "Collection of standard data structures for GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.2.5"
@@ -2570,7 +2505,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/DeepThought"
     },
-    "Status": "deposited",
     "Subtitle": "This package provides functions for computations in finitely generated nilpotent groups based on the Deep Thought algorithm.",
     "SupportEmail": "nina.wagner@math.uni-giessen.de",
     "TestFile": "tst/testall.g",
@@ -2578,7 +2512,6 @@
   },
   "design": {
     "AbstractHTML": "<span class=\"pkgname\">DESIGN</span> is a package for constructing, classifying, partitioning, and studying block designs.",
-    "AcceptDate": "08/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/design/releases/download/v1.7/design-1.7",
     "AvailabilityTest": null,
@@ -2586,7 +2519,6 @@
       "doc/manual.dvi",
       "doc/manual.pdf"
     ],
-    "CommunicatedBy": "Akos Seress (Ohio State)",
     "Date": "18/03/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2649,14 +2581,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/design"
     },
-    "Status": "accepted",
     "Subtitle": "The Design Package for GAP",
     "TestFile": "tst/testall.g",
     "Version": "1.7"
   },
   "difsets": {
     "AbstractHTML": "The <span class=\"pkgname\">DifSets</span> package is a         <span class=\"pkgname\">GAP</span> package implementing an algorithm         for enumerating all difference sets up to equivalence in a group.",
-    "AcceptDate": "07/2019",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/dylanpeifer/difsets/releases/download/v2.3.1/difsets-2.3.1",
     "AutoDoc": {
@@ -2666,7 +2596,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alexander Hulpke (Colorado State)",
     "Date": "14/09/2019",
     "Dependencies": {
       "GAP": "4.9",
@@ -2724,7 +2653,6 @@
       "Type": "git",
       "URL": "https://github.com/dylanpeifer/difsets"
     },
-    "Status": "accepted",
     "Subtitle": "an algorithm for enumerating all difference sets in a group",
     "SupportEmail": "djp282@cornell.edu",
     "TestFile": "tst/testall.g",
@@ -2952,19 +2880,16 @@
       "Type": "git",
       "URL": "https://github.com/digraphs/Digraphs"
     },
-    "Status": "deposited",
     "Subtitle": "Graphs, digraphs, and multidigraphs in GAP",
     "TestFile": "tst/testinstall.tst",
     "Version": "1.3.1"
   },
   "edim": {
     "AbstractHTML": "This package provides  a collection of functions for computing the Smith normal form of integer matrices and some related utilities.",
-    "AcceptDate": "08/1999",
     "ArchiveFormats": ".tar.bz2  .tar.gz   -win.zip",
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/EDIM-1.3.5",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Atkinson (St Andrews)",
     "Date": "13/08/2019",
     "Dependencies": {
       "ExternalConditions": [
@@ -3020,7 +2945,6 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/EDIM"
     },
-    "Status": "accepted",
     "Subtitle": "Elementary Divisors of Integer Matrices",
     "TestFile": "tst/edim.tst",
     "Version": "1.3.5"
@@ -3106,7 +3030,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/example"
     },
-    "Status": "deposited",
     "Subtitle": "Example/Template of a GAP Package",
     "SupportEmail": "obk1@st-andrews.ac.uk",
     "TestFile": "tst/testall.g",
@@ -3217,13 +3140,11 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Examples for the GAP Package homalg",
     "Version": "2020.10-02"
   },
   "factint": {
     "AbstractHTML": "\nThis package provides routines for factoring integers, in particular:\n<ul>\n  <li>Pollard's <em>p</em>-1</li>\n  <li>Williams' <em>p</em>+1</li>\n  <li>Elliptic Curves Method (ECM)</li>\n  <li>Continued Fraction Algorithm (CFRAC)</li>\n  <li>Multiple Polynomial Quadratic Sieve (MPQS)</li>\n</ul>\nIt also provides access to Richard P. Brent's tables of factors of integers of the form <em>b</em>^<em>k</em> +/- 1.\n",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/FactInt/releases/download/v1.6.3/FactInt-1.6.3",
     "AutoDoc": {
@@ -3234,7 +3155,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Atkinson (St. Andrews)",
     "Date": "15/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3305,7 +3225,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FactInt"
     },
-    "Status": "accepted",
     "Subtitle": "Advanced Methods for Factoring Integers",
     "TestFile": "tst/testall.g",
     "Version": "1.6.3"
@@ -3372,19 +3291,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ferret"
     },
-    "Status": "deposited",
     "Subtitle": "Backtrack Search in Permutation Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.0.3"
   },
   "fga": {
     "AbstractHTML": "The <span class=\"pkgname\">FGA</span> package installs methods for    computations with finitely generated subgroups of free groups and    provides a presentation for their automorphism groups.",
-    "AcceptDate": "05/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "http://www.icm.tu-bs.de/ag_algebra/software/FGA/FGA-1.4.0",
     "Autoload": true,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
     "Date": "23/03/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3431,19 +3347,16 @@
       "Type": "git",
       "URL": "https://github.com/chsievers/fga"
     },
-    "Status": "accepted",
     "Subtitle": "Free Group Algorithms",
     "TestFile": "tst/testall.g",
     "Version": "1.4.0"
   },
   "fining": {
     "AbstractHTML": "<span class=\"pkgname\">FinInG</span> is a package for computation in Finite Incidence Geometry. It provides users with the basic tools to work in  various areas of finite geometry from the realms of projective spaces to the flat  lands of generalised polygons. The algebraic power of GAP is employed, particularly  in its facility with matrix and permutation groups.",
-    "AcceptDate": "11/2017",
     "ArchiveFormats": ".tar.gz -win.zip .tar.bz2",
     "ArchiveURL": "http://cage.ugent.be/fining/archive/fining-1.4.1",
     "AvailabilityTest": null,
     "BannerString": "-------------------------------------------------------------------------------\n         ______________       ________      _________   __________ __          \n         ___  ____/__(_)__________  _/________  ____/   __<  /_  // /          \n         __  /_   __  /__  __ __  / __  __   / __     __  /_  // /_          \n         _  __/   _  / _  / / /_/ /  _  / / / /_/ /     _  /_/__  __/          \n         /_/      /_/  /_/ /_//___/  /_/ /_/____/      /_/_(_)/_/             \n-------------------------------------------------------------------------------\nLoading  FinInG 1.4.1 (Finite Incidence Geometry) \nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Anton Betten (http://www.math.colostate.edu/~betten)\n   Jan De Beule (http://www.debeule.eu)\n   Philippe Cara (http://homepages.vub.ac.be/~pcara)\n   Michel Lavrauw (http://people.sabanciuniv.edu/~mlavrauw/)\n   Max Neunhoeffer (http://www-groups.mcs.st-and.ac.uk/~neunhoef/)\nFor help, type: ?FinInG \n---------------------------------------------------------------------\n",
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
     "Date": "31/03/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3572,7 +3485,6 @@
       "Type": "git",
       "URL": "https://bitbucket.org/jdebeule/fining"
     },
-    "Status": "accepted",
     "Subtitle": "Finite Incidence Geometry",
     "TestFile": "tst/testall.g",
     "Version": "1.4.1"
@@ -3637,18 +3549,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/float"
     },
-    "Status": "deposited",
     "Subtitle": "Integration of mpfr, mpfi, mpc, fplll and cxsc in GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.9.1"
   },
   "format": {
     "AbstractHTML": "This package provides functions for computing with formations of finite solvable groups.",
-    "AcceptDate": "12/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/format/releases/download/v1.4.3/format-1.4.3",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3716,20 +3625,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/format"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with formations of finite solvable groups.",
     "TestFile": "tst/testall.g",
     "Version": "1.4.3"
   },
   "forms": {
     "AbstractHTML": "This package can be used for work with sesquilinear and quadratic forms on finite vector spaces; objects that are used to describe polar spaces and classical groups.",
-    "AcceptDate": "03/2009",
     "ArchiveFormats": ".tar.gz -win.zip .tar.bz2",
     "ArchiveURL": "http://cage.ugent.be/geometry/software/forms/forms-1.2.5",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "---------------------------------------------------------------------\nLoading 'Forms' 1.2.5 (27/09/2018)\nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Jan De Beule (http://www.debeule.eu)\nFor help, type: ?Forms \n---------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (London)",
     "Date": "27/09/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3789,18 +3695,15 @@
       }
     ],
     "README_URL": "http://cage.ugent.be/geometry/software/forms/README",
-    "Status": "accepted",
     "Subtitle": "Sesquilinear and Quadratic",
     "TestFile": "tst/testall.g",
     "Version": "1.2.5"
   },
   "fplsa": {
     "AbstractHTML": "The <span class=\"pkgname\">FPLSA</span> package uses    the authors' C program (version 4.0) that implements    a Lie Todd-Coxeter method for converting    finitely presented Lie algebras into isomorphic    structure constant algebras.    This is called via the GAP function IsomorphismSCTableAlgebra.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/FPLSA/releases/download/v1.2.4/FPLSA-1.2.4",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Steve Linton (St Andrews)",
     "Date": "07/07/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3863,7 +3766,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FPLSA"
     },
-    "Status": "accepted",
     "Subtitle": "Finitely Presented Lie Algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.2.4"
@@ -3875,7 +3777,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading FR 2.4.6 ...\n",
-    "CommunicatedBy": "G\u00f6tz Pfeiffer (NUI Galway)",
     "Date": "03/11/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3954,7 +3855,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/fr"
     },
-    "Status": "deposited",
     "Subtitle": "Computations with functionally recursive groups",
     "TestFile": "tst/testall.g",
     "Version": "2.4.6"
@@ -4028,7 +3928,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/Francy"
     },
-    "Status": "deposited",
     "Subtitle": "Framework for Interactive Discrete Mathematics",
     "TestFile": "tst/testall.g",
     "Version": "1.2.4"
@@ -4123,18 +4022,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/fwtree"
     },
-    "Status": "deposited",
     "Subtitle": "Computing trees related to some pro-p-groups of finite width",
     "TestFile": "tst/testall.g",
     "Version": "1.3"
   },
   "gapdoc": {
     "AbstractHTML": "This package contains a definition of a structure for <span class='pkgname'>GAP</span> (package) documentation, based on XML. It also contains  conversion programs for producing text-, PDF- or HTML-versions of such documents, with hyperlinks if possible.",
-    "AcceptDate": "10/2006",
     "ArchiveFormats": ".tar.bz2 .tar.gz -win.zip",
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.4",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Steve Linton (St Andrews)",
     "Date": "11/08/2020",
     "Dependencies": {
       "ExternalConditions": [
@@ -4217,7 +4113,6 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/GAPDoc"
     },
-    "Status": "accepted",
     "Subtitle": "A Meta Package for GAP Documentation",
     "Version": "1.6.4"
   },
@@ -4303,7 +4198,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Extended Gauss functionality for GAP",
     "Version": "2020.10-02"
   },
@@ -4386,18 +4280,15 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Gauss functionality for the homalg project",
     "Version": "2020.10-02"
   },
   "gbnp": {
     "AbstractHTML": "The <span class=\"pkgname\">GBNP</spam> package provides algorithms for    computing Grobner bases of noncommutative polynomials with coefficients    from a field implemented in <span class=\"pkgname\">GAP</span> and with    respect to the \"total degree first then lexicographical\" ordering.    Further provided are some variations, such as a weighted and truncated    version and a tracing facility. The word \"algorithm\" is to be    interpreted loosely here: in general one cannot expect such an algorithm    to terminate, as it would imply solvability of the word problem for    finitely presented (semi)groups.",
-    "AcceptDate": "05/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "http://mathdox.org/products/gbnp/GBNP-1.0.3",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alexander Hulpke (Fort Collins, CO)",
     "Date": "08/03/2016",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4456,7 +4347,6 @@
       }
     ],
     "README_URL": "http://mathdox.org/products/gbnp/README",
-    "Status": "accepted",
     "Subtitle": "computing Gr\u00f6bner bases of noncommutative polynomials",
     "TestFile": "test/test-all.tst",
     "Version": "1.0.3"
@@ -4533,7 +4423,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Implementations of generalized morphisms for the CAP project",
     "Version": "2020.10-01"
   },
@@ -4629,7 +4518,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/genss"
     },
-    "Status": "deposited",
     "Subtitle": "Generic Schreier-Sims",
     "TestFile": "tst/testall.g",
     "Version": "1.6.6"
@@ -4779,7 +4667,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings",
     "Version": "2020.10-02"
   },
@@ -4926,13 +4813,11 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Endow Commutative Rings with an Abelian Grading",
     "Version": "2020.10-02"
   },
   "grape": {
     "AbstractHTML": "<span class=\"pkgname\">GRAPE</span> is a package for computing with graphs and groups, and is primarily designed for constructing and analysing graphs related to groups, finite geometries, and designs.",
-    "AcceptDate": "07/1993",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/grape/releases/download/v4.8.3/grape-4.8.3",
     "AvailabilityTest": null,
@@ -4942,7 +4827,6 @@
       "nauty22/nug.pdf",
       "bin/i686-pc-cygwin-gcc-default32/dreadnautB.exe"
     ],
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "09/12/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4991,14 +4875,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/grape"
     },
-    "Status": "accepted",
     "Subtitle": "GRaph Algorithms using PErmutation groups",
     "TestFile": "tst/testall.g",
     "Version": "4.8.3"
   },
   "groupoids": {
     "AbstractHTML": "The groupoids package provides a collection of functions for computing with finite groupoids, graph of groups, and graphs of groupoids. These are based on the more basic structures of magmas with objects and their mappings. It provides functions for normal forms of elements in Free Products with Amalgamation and in HNN extensions. Up until April 2017 this package was named Gpd.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/groupoids/releases/download/v1.68/groupoids-1.68",
     "AutoDoc": {
@@ -5011,7 +4893,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading groupoids 1.68 (algorithms for finite groupoids)\nby Emma Moore and Chris Wensley (http://pages.bangor.ac.uk/~mas023/)\n--------------------------------------------------------------------\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "04/09/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5092,7 +4973,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/groupoids"
     },
-    "Status": "accepted",
     "Subtitle": "Calculations with finite groupoids and their homomorphisms",
     "SupportEmail": "c.d.wensley@bangor.ac.uk",
     "TestFile": "tst/testall.g",
@@ -5100,11 +4980,9 @@
   },
   "grpconst": {
     "AbstractHTML": "The <span class=\"pkgname\">GrpConst</span> package contains methods to construct up to isomorphism the groups of a given order. The FrattiniExtensionMethod constructs all soluble groups of a given order. On request it gives only those that are (or are not) nilpotent or supersolvable or that do (or do not) have normal Sylow subgroups for some given set of primes. The CyclicSplitExtensionMethod constructs all groups having a normal Sylow subgroup for orders of the type p^n *q. The method relies on the availability of a list of all groups of order p^n. The UpwardsExtensions algorithm takes as input a permutation group G and a positive integer s and returns a list of permutation groups, one for each extension of G by a soluble group of order a divisor of s. This method can used to construct the non-solvable groups of a given order by taking the perfect groups of certain orders as input for G. The programs in this package have been used to construct a large part of the Small Groups library.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/grpconst/releases/download/v2.6.2/grpconst-2.6.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5183,7 +5061,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/grpconst"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing the Groups of a Given Order",
     "TestFile": "tst/testall.g",
     "Version": "2.6.2"
@@ -5286,20 +5163,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/guarana"
     },
-    "Status": "deposited",
     "Subtitle": "Applications of Lie methods for computations with infinite polycyclic groups",
     "TestFile": "tst/testall.g",
     "Version": "0.96.2"
   },
   "guava": {
     "AbstractHTML": "<span class=\"pkgname\">GUAVA</span> is a <span class=\"pkgname\">GAP</span> package for computing with codes. <span class=\"pkgname\">GUAVA</span> can construct unrestricted (non-linear), linear and cyclic codes; transform one code into another (for example by puncturing); construct a new code from two other codes (using direct sums for example); perform decoding/error-correction; and can calculate important data of codes (such as the minumim distance or covering radius) quickly. Limited ability to compute algebraic geometric codes.",
-    "AcceptDate": "02/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/guava/releases/download/v3.15/guava-3.15",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\n   ____                          |\n  /            \\           /   --+--  Version 3.15\n /      |    | |\\\\        //|    |\n|    _  |    | | \\\\      // |     the GUAVA Group\n|     \\ |    | |--\\\\    //--|     \n \\     ||    | |   \\\\  //   |     \n  \\___/  \\___/ |    \\\\//    |      \n                                  \n\n",
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "13/04/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5448,19 +5322,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/guava"
     },
-    "Status": "accepted",
     "Subtitle": "a GAP package for computing with error-correcting codes",
     "TestFile": "tst/guava.tst",
     "Version": "3.15"
   },
   "hap": {
     "AbstractHTML": "This package provides some functions for group cohomology. ",
-    "AcceptDate": "03/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/hap/releases/download/v1.29/hap-1.29",
     "AvailabilityTest": null,
     "BannerString": "Loading HAP 1.29 ...\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "07/01/2021",
     "Dependencies": {
       "ExternalConditions": [
@@ -5587,7 +5458,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hap"
     },
-    "Status": "accepted",
     "Subtitle": "Homological Algebra Programming",
     "TestFile": "tst/testall.g",
     "Version": "1.29"
@@ -5703,7 +5573,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hapcryst"
     },
-    "Status": "deposited",
     "Subtitle": "A HAP extension for crystallographic groups",
     "TestFile": "tst/testall.g",
     "Version": "0.1.13"
@@ -5775,7 +5644,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hecke"
     },
-    "Status": "deposited",
     "Subtitle": "Calculating decomposition matrices of Hecke algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.5.3"
@@ -5879,7 +5747,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/HeLP"
     },
-    "Status": "deposited",
     "Subtitle": "Hertweck-Luthar-Passi method.",
     "TestFile": "tst/testall.g",
     "Version": "3.5"
@@ -5973,7 +5840,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homological algebra meta-package for computable Abelian categories",
     "Version": "2020.10-02"
   },
@@ -6115,13 +5981,11 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A window to the outer world",
     "Version": "2020.10-02"
   },
   "idrel": {
     "AbstractHTML": "IdRel is a package for computing the identities among relations of a group presentation using rewriting, logged rewriting, monoid polynomials, module polynomials and Y-sequences.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/idrel/releases/download/v2.43/idrel-2.43",
     "AutoDoc": {
@@ -6134,7 +5998,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading IdRel 2.43 (Identities among Relations)\nby Anne Heyworth and Chris Wensley (http://pages.bangor.ac.uk/~mas023/)\n-----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "29/05/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -6200,7 +6063,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/idrel"
     },
-    "Status": "accepted",
     "Subtitle": "Identities among relations",
     "TestFile": "tst/testall.g",
     "Version": "2.43"
@@ -6297,7 +6159,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/images"
     },
-    "Status": "dev",
     "Subtitle": "Minimal and Canonical images",
     "TestFile": "tst/testall.g",
     "Version": "1.3.0"
@@ -6368,7 +6229,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/intpic"
     },
-    "Status": "deposited",
     "Subtitle": "A package for drawing integers",
     "TestFile": "tst/testall.g",
     "Version": "0.2.4"
@@ -6450,7 +6310,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/io"
     },
-    "Status": "deposited",
     "Subtitle": "Bindings for low level C library I/O routines",
     "TestFile": "tst/testall.g",
     "Version": "4.7.0"
@@ -6567,19 +6426,16 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "IO capabilities for the homalg project",
     "Version": "2020.10-02"
   },
   "irredsol": {
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">IRREDSOL</span> provides a library of all irreducible soluble subgroups of <i>GL(n,q)</i>, up to conjugacy, for <i>q<sup>n</sup></i> up to 2^24-1, and a library of the primitive soluble groups of degree up to 2^24-1.",
-    "AcceptDate": "08/2006",
     "ArchiveFormats": ".tar.bz2",
     "ArchiveURL": "https://github.com/bh11/irredsol/releases/latest/download/irredsol-1.4.1",
     "Autoload": true,
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------------\n                          IRREDSOL Version 1.4.1\n  A library of irreducible soluble linear groups over finite fields\n                and of finite primivite soluble groups\n                         by Burkhard H\u00f6fling\n----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "10/03/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -6641,7 +6497,6 @@
       "Type": "git",
       "URL": "https://github.com/bh11/irredsol.git"
     },
-    "Status": "accepted",
     "Subtitle": "A library of irreducible soluble linear groups over finite fields and of finite primivite soluble groups",
     "TestFile": "tst/testall.g",
     "TextBinaryFilesPatterns": [
@@ -6652,13 +6507,11 @@
   },
   "itc": {
     "AbstractHTML": "This <span class=\"pkgname\">GAP</span> package provides    access to interactive Todd-Coxeter computations    with finitely presented groups.",
-    "AcceptDate": "03/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/itc/releases/download/v1.5/itc-1.5",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\n          Loading  ITC 1.5  (Interactive Todd-Coxeter)\n            by V. Felsch, L. Hippe, and J. Neubueser\n              (Volkmar.Felsch@math.rwth-aachen.de)\n\n",
-    "CommunicatedBy": "Edmund F. Robertson (St Andrews)",
     "Date": "13/06/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -6734,7 +6587,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/itc"
     },
-    "Status": "accepted",
     "Subtitle": "Interactive Todd-Coxeter",
     "Version": "1.5"
   },
@@ -6791,7 +6643,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/json"
     },
-    "Status": "deposited",
     "Subtitle": "Reading and Writing JSON",
     "TestFile": "tst/testall.g",
     "Version": "2.0.2"
@@ -6895,7 +6746,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/JupyterKernel"
     },
-    "Status": "deposited",
     "Subtitle": "Jupyter kernel written in GAP",
     "TestFile": "tst/testinstall.g",
     "Version": "1.3"
@@ -6964,7 +6814,6 @@
       "Type": "git",
       "URL": "https://github.com/nathancarter/jupyterviz"
     },
-    "Status": "dev",
     "Subtitle": "Visualization Tools for Jupyter and the GAP REPL",
     "SupportEmail": "ncarter@bentley.edu",
     "TestFile": "tst/testall.g",
@@ -6972,7 +6821,6 @@
   },
   "kan": {
     "AbstractHTML": "The Kan package provides functions for the computation of normal forms   of representatives of double cosets of finitely presented groups.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/kan/releases/download/v1.32/kan-1.32",
     "AutoDoc": {
@@ -6985,7 +6833,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading Kan 1.32 (computing with Kan extensions)\nby Anne Heyworth and Chris Wensley (http://pages.bangor.ac.uk/~mas023/)\n-----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "16/07/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7054,14 +6901,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/kan"
     },
-    "Status": "accepted",
     "Subtitle": "including double coset rewriting systems",
     "TestFile": "tst/testall.g",
     "Version": "1.32"
   },
   "kbmag": {
     "AbstractHTML": "The <span class=\"pkgname\">kbmag</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for running the Knuth-Bendix completion program on finite semigroup,   monoid or group presentations, and for attempting to compute automatic   structures of finitely presented groups",
-    "AcceptDate": "07/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/kbmag/releases/download/v1.5.9/kbmag-1.5.9",
     "AutoDoc": {
@@ -7073,7 +6918,6 @@
     },
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Oregon)",
     "Date": "07/07/2019",
     "Dependencies": {
       "ExternalConditions": [
@@ -7129,18 +6973,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/kbmag"
     },
-    "Status": "accepted",
     "Subtitle": "Knuth-Bendix on Monoids and Automatic Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.5.9"
   },
   "laguna": {
     "AbstractHTML": "The <span class=\"pkgname\">LAGUNA</span> package replaces the <span class=\"pkgname\">LAG</span> package and provides functionality for calculation of the normalized unit group of the modular group algebra of the finite p-group and for investigation of Lie algebra associated with group algebras and other associative algebras.",
-    "AcceptDate": "06/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/laguna/releases/download/v3.9.3/laguna-3.9.3",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "19/05/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7228,14 +7069,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/laguna"
     },
-    "Status": "accepted",
     "Subtitle": "Lie AlGebras and UNits of group Algebras",
     "TestFile": "tst/testall.g",
     "Version": "3.9.3"
   },
   "liealgdb": {
     "AbstractHTML": "",
-    "AcceptDate": "09/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liealgdb/releases/download/v2.2.1/liealgdb-2.2.1",
     "AutoDoc": {
@@ -7246,7 +7085,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "07/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7322,19 +7160,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liealgdb"
     },
-    "Status": "accepted",
     "Subtitle": "A database of Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "2.2.1"
   },
   "liepring": {
     "AbstractHTML": "",
-    "AcceptDate": "09/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liepring/releases/download/v1.9.2/liepring-1.9.2",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading  LiePRing 1.9.2\nby Michael Vaughan-Lee and Bettina Eick \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (London)",
     "Date": "11/10/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7396,14 +7231,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liepring"
     },
-    "Status": "accepted",
     "Subtitle": "Database and algorithms for Lie p-rings",
     "TestFile": "tst/testall.g",
     "Version": "1.9.2"
   },
   "liering": {
     "AbstractHTML": "The package <span class=\"pkgname\">LieRing</span> contains                  functionality for working with finitely presented Lie rings and the Lazard correspondence.",
-    "AcceptDate": "12/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liering/releases/download/v2.4.1/liering-2.4.1",
     "AutoDoc": {
@@ -7415,7 +7248,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "LieRing\n a package for working with Lie rings \n by Serena Cical\u00f2 and Willem de Graaf\n",
-    "CommunicatedBy": "Max Neunhoeffer (Cologne)",
     "Date": "23/02/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7480,7 +7312,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liering"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with finitely presented Lie rings",
     "TestFile": "tst/testall.g",
     "Version": "2.4.1"
@@ -7569,7 +7400,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Category of Matrices over a Field for CAP",
     "Version": "2020.10-01"
   },
@@ -7669,13 +7499,11 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A Package for Localization of Polynomial Rings",
     "Version": "2020.10-02"
   },
   "loops": {
     "AbstractHTML": "The LOOPS package provides researchers in nonassociative algebra with a computational tool that integrates standard notions of loop theory with libraries of loops and group-theoretical algorithms of GAP. The package also expands GAP toward nonassociative structures.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/loops/releases/download/v3.4.1/loops-3.4.1",
     "AutoDoc": {
@@ -7687,7 +7515,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "06/11/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7757,20 +7584,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/loops"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with quasigroups and loops in GAP",
     "TestFile": "tst/testall.g",
     "Version": "3.4.1"
   },
   "lpres": {
     "AbstractHTML": "The LPRES Package defines new GAP objects to work with L-presented groups, namely groups given by a finite generating set and a possibly-infinite set of relations given as iterates of finitely many seed relations by a finite set of endomorphisms. The package implements nilpotent quotient, Todd-Coxeter and Reidemeister-Schreier algorithms for L-presented groups.",
-    "AcceptDate": "09/2018",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/lpres/releases/download/v1.0.1/lpres-1.0.1",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading lpres 1.0.1 ...\n",
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
     "Date": "14/11/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7859,7 +7683,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/lpres"
     },
-    "Status": "accepted",
     "Subtitle": "Nilpotent Quotients of L-Presented Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.0.1"
@@ -7953,7 +7776,6 @@
       "Type": "git",
       "URL": "https://github.com/MWhybrow92/MajoranaAlgebras"
     },
-    "Status": "dev",
     "Subtitle": "A package for constructing Majorana algebras and representations",
     "SupportEmail": "mlw10@ic.ac.uk",
     "TestFile": "tst/testall.g",
@@ -7961,12 +7783,10 @@
   },
   "mapclass": {
     "AbstractHTML": "The <span class=\"pkgname\">MapClass</span> package calculates the    mapping class group orbits for a given finite group.",
-    "AcceptDate": "11/2011",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/MapClass/releases/download/v1.4.4/MapClass-1.4.4",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "02/12/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8033,7 +7853,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/MapClass"
     },
-    "Status": "accepted",
     "Subtitle": "A Package For Mapping Class Orbit Computation",
     "TestFile": "tst/testall.g",
     "Version": "1.4.4"
@@ -8115,7 +7934,6 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/matgrp/"
     },
-    "Status": "deposited",
     "Subtitle": "Matric Group Interface Routines",
     "TestFile": "tst/testall.g",
     "Version": "0.64"
@@ -8225,19 +8043,16 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Matrices for the homalg project",
     "Version": "2020.10-04"
   },
   "modisom": {
     "AbstractHTML": "The <span class=\"pkgname\">ModIsom</span> package contains various methods for computing with nilpotent associative algebras. In particular, it contains a method to determine the automorphism group and to test isomorphis of such algebras over finite fields and of modular group algebras of finite p-groups, and it contains a nilpotent quotient algorithm for finitely presented associative algebras and a method to determine Kurosh algebras.",
-    "AcceptDate": "11/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/modisom/releases/download/v2.5.1/modisom-2.5.1",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading ModIsom 2.5.1... \n",
-    "CommunicatedBy": "Olexandr Konovalov (St. Andrews)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8307,7 +8122,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/modisom"
     },
-    "Status": "accepted",
     "Subtitle": "Computing automorphisms and checking isomorphisms for modular group algebras of finite p-groups",
     "TestFile": "tst/testall.g",
     "Version": "2.5.1"
@@ -8392,7 +8206,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Category R-pres for CAP",
     "Version": "2020.10-01"
   },
@@ -8528,7 +8341,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homalg based package for the Abelian category of finitely presented modules over computable rings",
     "Version": "2020.10-02"
   },
@@ -8622,7 +8434,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Monoidal and monoidal (co)closed categories",
     "TestFile": "tst/testall.g",
     "Version": "2020.10-01"
@@ -8720,20 +8531,17 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/NConvex"
     },
-    "Status": "deposited",
     "Subtitle": "A Gap package to perform polyhedral computations",
     "TestFile": "tst/testall.g",
     "Version": "2020.11-04"
   },
   "nilmat": {
     "AbstractHTML": "The <span class=\"pkgname\">Nilmat</span> package contains methods for checking whether a finitely generated matrix group over a finite field or the field of rational numbers is nilpotent, methods for computing with such nilpotent matrix groups and methods for constructing important classes of such nilpotent matrix groups.",
-    "AcceptDate": "08/2007",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/nilmat/releases/download/v1.4/nilmat-1.4",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading Nilmat 1.4...\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "09/02/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8810,19 +8618,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/nilmat"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with nilpotent matrix groups",
     "TestFile": "tst/testall.g",
     "Version": "1.4"
   },
   "nock": {
     "AbstractHTML": "The <span class=\"pkgname\">NoCK</span> package    is used for computing Tolzanos's obstruction    for compact Clifford-Klein forms",
-    "AcceptDate": "07/2019",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/pjastr/NoCK/releases/download/v1.4/NoCK-1.4",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nNoCK Package 1.4\nby Maciej Boche\u0144ski, Piotr Jastrz\u0119bski, Anna Szczepkowska, Aleksy Tralle, Artur Woike.\n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "22/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8920,7 +8725,6 @@
       "Type": "git",
       "URL": "https://github.com/pjastr/NoCK"
     },
-    "Status": "accepted",
     "Subtitle": "NoCK-Package for computing obstruction for compact Clifford-Klein forms.",
     "SupportEmail": "piojas@matman.uwm.edu.pl",
     "TestFile": "tst/testall.g",
@@ -9002,14 +8806,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/NormalizInterface"
     },
-    "Status": "dev",
     "Subtitle": "GAP wrapper for Normaliz",
     "TestFile": "tst/testall.g",
     "Version": "1.1.0"
   },
   "nq": {
     "AbstractHTML": "This package provides access to the ANU nilpotent quotient program for computing nilpotent factor groups of finitely presented groups.",
-    "AcceptDate": "01/2003",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/nq/releases/download/v2.5.4/nq-2.5.4",
     "AutoDoc": {
@@ -9023,7 +8825,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading nq 2.5.4 (Nilpotent Quotient Algorithm)\n  by Werner Nickel\n  maintained by Max Horn (max.horn@math.uni-giessen.de)\n",
-    "CommunicatedBy": "Joachim Neub\u00fcser (RWTH Aachen)",
     "Date": "15/02/2019",
     "Dependencies": {
       "ExternalConditions": [
@@ -9096,19 +8897,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/nq"
     },
-    "Status": "accepted",
     "Subtitle": "Nilpotent Quotients of Finitely Presented Groups",
     "TestFile": "tst/testall.g",
     "Version": "2.5.4"
   },
   "numericalsgps": {
     "AbstractHTML": "The <span class=\"pkgname\">NumericalSgps</span> package, is a package to compute with numerical semigroups.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/numericalsgps/releases/download/v1.2.2/NumericalSgps-1.2.2",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading  NumericalSgps 1.2.2\nFor help, type: ?NumericalSgps: \nTo gain profit from other packages, please refer to chapter\n'External Packages' in the manual, or type: ?NumSgpsUse \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "03/03/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9286,19 +9084,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/numericalsgps"
     },
-    "Status": "accepted",
     "Subtitle": "A package for numerical semigroups",
     "TestFile": "tst/testall.g",
     "Version": "1.2.2"
   },
   "openmath": {
     "AbstractHTML": "This package provides an <a href=\"http://www.openmath.org/\">OpenMath</a> phrasebook for <span class=\"pkgname\">GAP</span>. This package allows <span class=\"pkgname\">GAP</span> users to import and export mathematical objects encoded in OpenMath, for the purpose of exchanging them with other applications that are OpenMath enabled.",
-    "AcceptDate": "08/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/openmath/releases/download/v11.5.0/OpenMath-11.5.0",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "09/02/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9380,7 +9175,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/openmath"
     },
-    "Status": "accepted",
     "Subtitle": "OpenMath functionality in GAP",
     "TestFile": "tst/testall.g",
     "Version": "11.5.0"
@@ -9480,7 +9274,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/orb"
     },
-    "Status": "deposited",
     "Subtitle": "Methods to enumerate orbits",
     "TestFile": "tst/testall.g",
     "Version": "4.8.3"
@@ -9543,7 +9336,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/PackageManager"
     },
-    "Status": "deposited",
     "Subtitle": "Easily download and install GAP packages",
     "TestFile": "tst/test-without-texlive.g",
     "Version": "1.1"
@@ -9635,18 +9427,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/PatternClass"
     },
-    "Status": "deposited",
     "Subtitle": "A permutation pattern class package",
     "TestFile": "tst/testall.g",
     "Version": "2.4.2"
   },
   "permut": {
     "AbstractHTML": "This package provides functions for computing with permutability in finite groups.",
-    "AcceptDate": "04/2014",
     "ArchiveFormats": ".tar.gz .tar.bz2 .zip",
     "ArchiveURL": "https://github.com/gap-packages/permut/releases/download/v2.0.3/permut-2.0.3",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alice Niemeyer (Perth)",
     "Date": "19/08/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9725,7 +9514,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/permut"
     },
-    "Status": "accepted",
     "Subtitle": "A package to deal with permutability in finite groups",
     "SupportEmail": "Ramon.Esteban@uv.es",
     "TestFile": "tst/testall.g",
@@ -9733,7 +9521,6 @@
   },
   "polenta": {
     "AbstractHTML": "The <span class=\"pkgname\">Polenta</span> package provides  methods to compute polycyclic presentations of matrix groups (finite or infinite). As a by-product, this package gives some functionality to compute certain module series for modules of solvable groups. For example, if G is a rational polycyclic matrix group, then we can compute the radical series of the natural Q[G]-module Q^d.",
-    "AcceptDate": "08/2005",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/polenta/releases/download/v1.3.9/polenta-1.3.9",
     "AutoDoc": {
@@ -9744,7 +9531,6 @@
     },
     "Autoload": true,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "01/10/2019",
     "Dependencies": {
       "GAP": ">= 4.7",
@@ -9821,14 +9607,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polenta"
     },
-    "Status": "accepted",
     "Subtitle": "Polycyclic presentations for matrix groups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.9"
   },
   "polycyclic": {
     "AbstractHTML": "This package provides various algorithms for computations with polycyclic groups defined by polycyclic presentations.",
-    "AcceptDate": "01/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/polycyclic/releases/download/v2.16/polycyclic-2.16",
     "AutoDoc": {
@@ -9838,7 +9622,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "25/07/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9939,7 +9722,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polycyclic"
     },
-    "Status": "accepted",
     "Subtitle": "Computation with polycyclic groups",
     "TestFile": "tst/testall.g",
     "Version": "2.16"
@@ -10017,7 +9799,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polymaking"
     },
-    "Status": "deposited",
     "Subtitle": "Interfacing the geometry software polymake",
     "TestFile": "tst/testall.g",
     "Version": "0.8.2"
@@ -10108,7 +9889,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/primgrp"
     },
-    "Status": "deposited",
     "Subtitle": "GAP Primitive Permutation Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "3.4.1"
@@ -10170,7 +9950,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/profiling"
     },
-    "Status": "dev",
     "Subtitle": "Line by line profiling and code coverage for GAP",
     "TestFile": "tst/testall.g",
     "Version": "2.3"
@@ -10245,14 +10024,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/qpa"
     },
-    "Status": "deposited",
     "Subtitle": "Quivers and Path Algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.31"
   },
   "quagroup": {
     "AbstractHTML": "The package <span class=\"pkgname\">QuaGroup</span> contains                  functionality for working with quantized enveloping algebras                 of finite-dimensional semisimple Lie algebras.",
-    "AcceptDate": "10/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/quagroup/releases/download/v1.8.2/quagroup-1.8.2",
     "AutoDoc": {
@@ -10263,7 +10040,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "     |                                                                 \n     |          QuaGroup 1.8.2\n     |                                                                 \n-----------     A package for dealing with quantized enveloping algebras\n     |                                                                 \n     |          Willem de Graaf                                        \n     |          degraaf@science.unitn.it                               \n\n",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "01/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10317,19 +10093,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/quagroup"
     },
-    "Status": "accepted",
     "Subtitle": "Computations with quantum groups",
     "TestFile": "tst/testall.g",
     "Version": "1.8.2"
   },
   "radiroot": {
     "AbstractHTML": "The <span class=\"pkgname\">RadiRoot</span> package installs a method to    display the roots of a rational polynomial as radicals if it is solvable.",
-    "AcceptDate": "02/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/radiroot/releases/download/v2.8/radiroot-2.8",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St Andrews)",
     "Date": "23/04/2018",
     "Dependencies": {
       "ExternalConditions": [
@@ -10388,14 +10161,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/radiroot"
     },
-    "Status": "accepted",
     "Subtitle": "Roots of a Polynomial as Radicals",
     "TestFile": "tst/testall.g",
     "Version": "2.8"
   },
   "rcwa": {
     "AbstractHTML": "This package provides implementations of algorithms and methods for computation in certain infinite permutation groups. For an abstract, see <a href = \"https://gap-packages.github.io/rcwa/\">here</a>.",
-    "AcceptDate": "04/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/rcwa/releases/download/v4.6.4/rcwa-4.6.4",
     "AutoDoc": {
@@ -10407,7 +10178,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "\nLoading RCWA 4.6.4 ([R]esidue-[C]lass-[W]ise [A]ffine groups)\n  by Stefan Kohl, stefan@mcs.st-and.ac.uk.\nSee ?RCWA:About for information about the package.\n\n",
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "24/03/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10483,18 +10253,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/rcwa"
     },
-    "Status": "accepted",
     "Subtitle": "Residue-Class-Wise Affine Groups",
     "TestFile": "tst/testall.g",
     "Version": "4.6.4"
   },
   "rds": {
     "AbstractHTML": "This package provides functions for the complete enumeration of relative difference sets.",
-    "AcceptDate": "02/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/rds/releases/download/v1.7/rds-1.7",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
     "Date": "23/02/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10559,7 +10326,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/rds"
     },
-    "Status": "accepted",
     "Subtitle": "A package for searching relative difference sets",
     "TestFile": "tst/testall.g",
     "Version": "1.7"
@@ -10761,7 +10527,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/recog"
     },
-    "Status": "deposited",
     "Subtitle": "A collection of group recognition methods",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
@@ -10841,14 +10606,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/RepnDecomp"
     },
-    "Status": "dev",
     "Subtitle": "Decompose representations of finite groups into irreducibles",
     "TestFile": "tst/testall.g",
     "Version": "1.1.0"
   },
   "repsn": {
     "AbstractHTML": "The package provides <span class=\"pkgname\">GAP</span> functions for computing characteristic zero matrix representations of finite groups.",
-    "AcceptDate": "05/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/repsn/releases/download/v3.1.0/repsn-3.1.0",
     "AutoDoc": {
@@ -10857,7 +10620,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "22/02/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10914,7 +10676,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/repsn"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing representations of finite groups",
     "TestFile": "tst/testall.g",
     "Version": "3.1.0"
@@ -10995,7 +10756,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/resclasses"
     },
-    "Status": "deposited",
     "Subtitle": "Set-Theoretic Computations with Residue Classes",
     "TestFile": "tst/testall.g",
     "Version": "4.7.2"
@@ -11171,7 +10931,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Dictionaries of external rings",
     "Version": "2020.11-01"
   },
@@ -11257,13 +11016,11 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "SCO - Simplicial Cohomology of Orbifolds",
     "Version": "2020.10-02"
   },
   "scscp": {
     "AbstractHTML": "This package implements the <a href=\"https://www.openmath.org/standard/scscp/\">Symbolic Computation Software Composability Protocol</a> for the GAP system.",
-    "AcceptDate": "08/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/scscp/releases/download/v2.3.1/SCSCP-2.3.1",
     "Autoload": false,
@@ -11271,7 +11028,6 @@
     "BinaryFiles": [
       "demo/maple2gap.mw"
     ],
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "22/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11347,7 +11103,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/scscp"
     },
-    "Status": "accepted",
     "Subtitle": "Symbolic Computation Software Composability Protocol in GAP",
     "TestFile": "tst/offline.tst",
     "Version": "2.3.1"
@@ -11621,19 +11376,16 @@
       "Type": "git",
       "URL": "https://github.com/semigroups/Semigroups"
     },
-    "Status": "deposited",
     "Subtitle": "A package for semigroups and monoids",
     "TestFile": "tst/teststandard.g",
     "Version": "3.4.0"
   },
   "sglppow": {
     "AbstractHTML": "",
-    "AcceptDate": "08/2016",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sglppow/releases/download/v2.1/sglppow-2.1",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading SglPPow 2.1\nby Michael Vaughan-Lee and Bettina Eick \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "08/03/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11699,7 +11451,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sglppow"
     },
-    "Status": "accepted",
     "Subtitle": "Database of groups of prime-power order for some prime-powers",
     "TestFile": "tst/testall.g",
     "Version": "2.1"
@@ -11769,20 +11520,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sgpviz"
     },
-    "Status": "deposited",
     "Subtitle": "A package for semigroup visualization",
     "TestFile": "tst/testall.g",
     "Version": "0.999.4"
   },
   "simpcomp": {
     "AbstractHTML": "<span class=\"pkgname\">simpcomp</span> is a <span class=\"pkgname\">GAP</span> package for working with simplicial complexes. It allows the computation of many properties of simplicial complexes (such as the f-, g- and h-vectors, the face lattice, the automorphism group, (co-)homology with explicit basis computation, intersection form, etc.) and provides the user with functions to compute new complexes from old (simplex links and stars, connected sums, cartesian products, handle additions, bistellar flips, etc.). Furthermore, it comes with an extensive library of known triangulations of manifolds and provides the user with the possibility to create own complex libraries.<br /> <span class=\"pkgname\">simpcomp</span> caches computed properties of a simplicial complex, thus avoiding unnecessary computations, internally handles the vertex labeling of the complexes and insures the consistency of a simplicial complex throughout all operations.<br /> <span class=\"pkgname\">simpcomp</span> relies on the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">homology</span> for its homology computation, but also provides the user with an own (co-)homology algorithm in case the packacke <span class=\"pkgname\">homology</span> is not available. For automorphism group computation the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">GRAPE</span> is used, which in turn uses the program <tt>nauty</tt> by Brendan McKay. An internal automorphism group calculation algorithm in used as fallback if the <span class=\"pkgname\">GRAPE</span> package is not available.",
-    "AcceptDate": "11/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "http://github.com/simpcomp-team/simpcomp/releases/download/v2.1.10/simpcomp-2.1.10",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading simpcomp 2.1.10\nby F. Effenberger and J. Spreer\nhttps://github.com/simpcomp-team/simpcomp\n",
-    "CommunicatedBy": "Graham Ellis (Galway)",
     "Date": "03/06/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11882,7 +11630,6 @@
       "Type": "git",
       "URL": "https://github.com/simpcomp-team/simpcomp"
     },
-    "Status": "accepted",
     "Subtitle": "A GAP toolbox for simplicial complexes",
     "TestFile": "tst/simpcomp.tst",
     "Version": "2.1.10"
@@ -11959,14 +11706,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/singular"
     },
-    "Status": "deposited",
     "Subtitle": "A GAP interface to Singular",
     "TestFile": "tst/testall.g",
     "Version": "2020.12.18"
   },
   "sla": {
     "AbstractHTML": "The package <span class=\"pkgname\">SLA</span> contains                  functionality for working with simple Lie algebras,",
-    "AcceptDate": "01/2016",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sla/releases/download/v1.5.3/sla-1.5.3",
     "AutoDoc": {
@@ -11977,7 +11722,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "15/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12037,18 +11781,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sla"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with simple Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.5.3"
   },
   "smallgrp": {
     "AbstractHTML": "The <span class=\"smallgrp\">SmallGrp</span> package provides the library of groups of certain \"small\" orders. The groups are sorted by their orders and they are listed up to isomorphism; that is, for each of the available orders a complete and irredundant list of isomorphism type representatives of groups is given.",
-    "AcceptDate": "02/2002",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/SmallGrp/releases/download/v1.4.2/SmallGrp-1.4.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Newman (Canberra)",
     "Date": "18/12/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12121,7 +11862,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/SmallGrp"
     },
-    "Status": "accepted",
     "Subtitle": "The GAP Small Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "1.4.2"
@@ -12206,19 +11946,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/smallsemi"
     },
-    "Status": "deposited",
     "Subtitle": "A library of small semigroups",
     "TestFile": "tst/testall.g",
     "Version": "0.6.12"
   },
   "sonata": {
     "AbstractHTML": "The <span class=\"pkgname\">SONATA</span> package provides methods for     the construction and analysis of finite nearrings.",
-    "AcceptDate": "04/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sonata/releases/download/v2.9.1/sonata-2.9.1",
     "AvailabilityTest": null,
     "BannerString": "\n  ___________________________________________________________________________\n /        ___\n||       /   \\                 /\\    Version 2.9.1\n||      ||   ||  |\\    |      /  \\               /\\       Erhard Aichinger\n \\___   ||   ||  |\\\\   |     /____\\_____________/__\\      Franz Binder\n     \\  ||   ||  | \\\\  |    /      \\     ||    /    \\     Juergen Ecker\n     ||  \\___/   |  \\\\ |   /        \\    ||   /      \\    Peter Mayr\n     ||          |   \\\\|  /          \\   ||               Christof Noebauer\n \\___/           |    \\|                 ||\n\n System    Of   Nearrings     And      Their Applications\n Info: https://gap-packages.github.io/sonata/\n\n",
-    "CommunicatedBy": "Charles R.B. Wright (Univ. of Oregon)",
     "Date": "07/10/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12324,14 +12061,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sonata"
     },
-    "Status": "accepted",
     "Subtitle": "System of nearrings and their applications",
     "TestFile": "tst/testall.g",
     "Version": "2.9.1"
   },
   "sophus": {
     "AbstractHTML": "",
-    "AcceptDate": "10/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sophus/releases/download/v1.24/sophus-1.24",
     "AutoDoc": {
@@ -12342,7 +12077,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Olexandr Konovalov (Zaporozhye)",
     "Date": "09/04/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12401,7 +12135,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sophus"
     },
-    "Status": "accepted",
     "Subtitle": "Computing in nilpotent Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.24"
@@ -12482,18 +12215,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/spinsym"
     },
-    "Status": "deposited",
     "Subtitle": "Brauer tables of spin-symmetric groups",
     "TestFile": "tst/testall.tst",
     "Version": "1.5.2"
   },
   "symbcompcc": {
     "AbstractHTML": "The <span class=\"pkgname\">SymbCompCC</span> package computes with parametrised presentations for finite p-groups of fixed coclass.",
-    "AcceptDate": "11/2011",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/SymbCompCC/releases/download/v1.3.1/SymbCompCC-1.3.1",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Newman (Canberra, Australia)",
     "Date": "27/09/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12552,7 +12282,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/SymbCompCC"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with parametrised presentations for p-groups of fixed coclass",
     "TestFile": "tst/testall.g",
     "Version": "1.3.1"
@@ -12627,7 +12356,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/Thelma"
     },
-    "Status": "dev",
     "Subtitle": "A package on threshold elements",
     "TestFile": "tst/testall.g",
     "Version": "1.02"
@@ -12719,7 +12447,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/tomlib"
     },
-    "Status": "deposited",
     "Subtitle": "The GAP Library of Tables of Marks",
     "TestFile": "tst/testall.g",
     "Version": "1.2.9"
@@ -12810,13 +12537,11 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Special methods and knowledge propagation tools",
     "Version": "2020.10-03"
   },
   "toric": {
     "AbstractHTML": "<span class=\"pkgname\">toric</span> is a <span class=\"pkgname\">GAP</span>package for computing with toric varieties.",
-    "AcceptDate": "10/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/toric/releases/download/v1.9.5/Toric-1.9.5",
     "AutoDoc": {
@@ -12827,7 +12552,6 @@
     },
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "07/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12885,7 +12609,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/toric"
     },
-    "Status": "accepted",
     "Subtitle": "toric varieties and some combinatorial geometry computations",
     "TestFile": "tst/testall.g",
     "Version": "1.9.5"
@@ -12996,7 +12719,6 @@
       "Type": "git",
       "URL": "https://homalg-project.github.io/ToricVarieties_project/ToricVarieties"
     },
-    "Status": "deposited",
     "Subtitle": "A package to handle toric varieties",
     "Version": "2021.01.12"
   },
@@ -13051,7 +12773,6 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/transgrp"
     },
-    "Status": "deposited",
     "Subtitle": "Transitive Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "3.0"
@@ -13118,18 +12839,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/unipot"
     },
-    "Status": "deposited",
     "Subtitle": "Computing with elements of unipotent subgroups of Chevalley groups",
     "TestFile": "tst/testall.g",
     "Version": "1.4"
   },
   "unitlib": {
     "AbstractHTML": "The <span class=\"pkgname\">UnitLib</span> package extends the <span class=\"pkgname\">LAGUNA</span> package and provides the library of normalized unit groups of modular group algebras of all finite p-groups of order less than 243 over the field of p elements.",
-    "AcceptDate": "03/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/unitlib/releases/download/v4.0.0/unitlib-4.0.0",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "01/05/2018",
     "Dependencies": {
       "ExternalConditions": [
@@ -13206,7 +12924,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/unitlib"
     },
-    "Status": "accepted",
     "Subtitle": "Library of normalized unit groups of modular group algebras",
     "TestFile": "tst/testall.g",
     "Version": "4.0.0"
@@ -13324,7 +13041,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/utils"
     },
-    "Status": "deposited",
     "Subtitle": "Utility functions in GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.69"
@@ -13385,7 +13101,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/uuid"
     },
-    "Status": "dev",
     "Subtitle": "RFC 4122 UUIDs",
     "TestFile": "tst/testall.g",
     "Version": "0.6"
@@ -13466,18 +13181,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/walrus"
     },
-    "Status": "dev",
     "Subtitle": "A new approach to proving hyperbolicity",
     "TestFile": "tst/testall.g",
     "Version": "0.999"
   },
   "wedderga": {
     "AbstractHTML": "<span class=\"pkgname\">Wedderga</span> is the package to compute the simple components of the Wedderburn decomposition of semisimple group algebras of finite groups over finite fields and over subfields of finite cyclotomic extensions of the rationals. It also contains functions that produce the primitive central idempotents of semisimple group algebras and functions for computing Schur indices. Other functions of <span class=\"pkgname\">Wedderga</span> allow one to construct crossed products over a group with coefficients in an associative ring with identity and the multiplication determined by a given action and twisting.",
-    "AcceptDate": "01/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/wedderga/releases/download/v4.10.0/wedderga-4.10.0",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "15/05/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13625,18 +13337,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/wedderga"
     },
-    "Status": "accepted",
     "Subtitle": "Wedderburn Decomposition of Group Algebras",
     "TestFile": "tst/testall.g",
     "Version": "4.10.0"
   },
   "xgap": {
     "AbstractHTML": "The <span class=\"pkgname\">XGAP</span> package allows to use graphics in GAP.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xgap/releases/download/v4.30/xgap-4.30",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hi\u00df (Aachen)",
     "Date": "16/04/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13699,13 +13408,11 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xgap"
     },
-    "Status": "accepted",
     "Subtitle": "a graphical user interface for GAP",
     "Version": "4.30"
   },
   "xmod": {
     "AbstractHTML": "The <span class=\"pkgname\">XMod</span> package provides a collection   of functions for computing with crossed modules and cat1-groups, their derivations and sections, morphisms of these structures, and higher-dimensional generalisations.",
-    "AcceptDate": "12/1996",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xmod/releases/download/v2.82/XMod-2.82",
     "AutoDoc": {
@@ -13718,7 +13425,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading XMod 2.82 (methods for crossed modules and cat1-groups)\nby Chris Wensley (http://pages.bangor.ac.uk/~mas023/),\n with contributions from:\n    Murat Alp (muratalp@nigde.edu.tr),\n    Alper Odabas (aodabas@ogu.edu.tr),\nand Enver Uslu.\n-----------------------------------------------------------------------------\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "23/10/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13827,7 +13533,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmod"
     },
-    "Status": "accepted",
     "Subtitle": "Crossed Modules and Cat1-Groups",
     "SupportEmail": "c.d.wensley@bangor.ac.uk",
     "TestFile": "tst/testall.g",
@@ -13835,7 +13540,6 @@
   },
   "xmodalg": {
     "AbstractHTML": "The <span class=\"pkgname\">XModAlg</span> package provides a collection of functions for computing with crossed modules and cat1-algebras and morphisms of these structures.",
-    "AcceptDate": "",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xmodalg/releases/download/v1.18/XModAlg-1.18",
     "AutoDoc": {
@@ -13848,7 +13552,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "-----------------------------------------------------------------------------\nLoading XModAlg 1.18 (17/11/2020) for GAP 4.11 \nMethods for crossed modules of commutative algebras and cat1-algebras\nby Zekeriya Arvasi (zarvasi@ogu.edu.tr) and Alper Odabas (aodabas@ogu.edu.tr).\n-----------------------------------------------------------------------------\n",
-    "CommunicatedBy": "",
     "Date": "17/11/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13915,7 +13618,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmodalg"
     },
-    "Status": "deposited",
     "Subtitle": "Crossed Modules and Cat1-Algebras",
     "SupportEmail": "aodabas@ogu.edu.tr",
     "TestFile": "tst/testall.g",
@@ -13988,7 +13690,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/YangBaxter"
     },
-    "Status": "deposited",
     "Subtitle": "Combinatorial Solutions for the Yang-Baxter equation",
     "TestFile": "tst/testall.g",
     "Version": "0.9.0"
@@ -14075,7 +13776,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ZeroMQInterface"
     },
-    "Status": "dev",
     "Subtitle": "ZeroMQ bindings for GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.12"

--- a/_data/package-infos/4-12-0.json
+++ b/_data/package-infos/4-12-0.json
@@ -63,19 +63,16 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A link to 4ti2",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
   },
   "ace": {
     "AbstractHTML": "The <span class=\"pkgname\">ACE</span> package provides both an    interactive and non-interactive interface with the Todd-Coxeter coset   enumeration functions of the ACE (Advanced Coset Enumerator) C program.",
-    "AcceptDate": "04/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/ace/releases/download/v5.5/ace-5.5",
     "AvailabilityTest": null,
     "BannerString": "---------------------------------------------------------------------------\nLoading    ACE (Advanced Coset Enumerator) 5.5\nGAP code by Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)\n       Alexander Hulpke (https://www.math.colostate.edu/~hulpke)\n           [uses ACE binary (C code program) version: 3.001]\nC code by  George Havas (http://staff.itee.uq.edu.au/havas)\n           Colin Ramsay <cram@itee.uq.edu.au>\nCo-maintainer: Max Horn <horn@mathematik.uni-kl.de>\n\n                 For help, type: ?ACE\n---------------------------------------------------------------------------\n",
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "01/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -172,18 +169,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ace"
     },
-    "Status": "accepted",
     "Subtitle": "Advanced Coset Enumerator",
     "TestFile": "tst/aceds.tst",
     "Version": "5.5"
   },
   "aclib": {
     "AbstractHTML": "The <span class=\"pkgname\">AClib</span> package contains a library of almost crystallographic groups and a some algorithms to compute with these groups. A group is called almost crystallographic if it is finitely generated nilpotent-by-finite and has no non-trivial finite normal subgroups. Further, an almost crystallographic group is called almost Bieberbach if it is torsion-free. The almost crystallographic groups of Hirsch length 3 and a part of the almost cyrstallographic groups of Hirsch length 4 have been classified by Dekimpe. This classification includes all almost Bieberbach groups of Hirsch lengths 3 or 4. The AClib package gives access to this classification; that is, the package contains this library of groups in a computationally useful form. The groups in this library are available in two different representations. First, each of the groups of Hirsch length 3 or 4 has a rational matrix representation of dimension 4 or 5, respectively, and such representations are available in this package. Secondly, all the groups in this libraray are (infinite) polycyclic groups and the package also incorporates polycyclic presentations for them. The polycyclic presentations can be used to compute with the given groups using the methods of the Polycyclic package.",
-    "AcceptDate": "02/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/aclib/releases/download/v1.3.2/aclib-1.3.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -257,7 +251,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/aclib"
     },
-    "Status": "accepted",
     "Subtitle": "Almost Crystallographic Groups - A Library and Algorithms",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
@@ -335,7 +328,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/AGT"
     },
-    "Status": "other",
     "Subtitle": "Algebraic Graph Theory",
     "SupportEmail": "r.evans@qmul.ac.uk",
     "TestFile": "tst/testall.g",
@@ -343,11 +335,9 @@
   },
   "alnuth": {
     "AbstractHTML": "The <span class=\"pkgname\">Alnuth</span> package provides various methods to compute with number fields which are given by a defining polynomial or by generators. Some of the methods provided in this package are written in <span class=\"pkgname\">GAP</span> code. The other part of the methods is imported from the computer algebra system PARI/GP. Hence this package contains some <span class=\"pkgname\">GAP</span> functions and an interface to some functions in the computer algebra system PARI/GP. The main methods included in <span class=\"pkgname\">Alnuth</span> are: creating a number field, computing its maximal order (using PARI/GP), computing its unit group (using PARI/GP) and a presentation of this unit group, computing the elements of a given norm of the number field (using PARI/GP), determining a presentation for a finitely generated multiplicative subgroup (using PARI/GP), and factoring polynomials defined over number fields (using PARI/GP).",
-    "AcceptDate": "01/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/alnuth/releases/download/v3.2.1/alnuth-3.2.1",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "05/04/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -431,14 +421,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/alnuth"
     },
-    "Status": "accepted",
     "Subtitle": "Algebraic number theory and an interface to PARI/GP",
     "TestFile": "tst/testall.g",
     "Version": "3.2.1"
   },
   "anupq": {
     "AbstractHTML": "The <span class=\"pkgname\">ANUPQ</span> package provides an interactive    interface to the p-quotient, p-group generation and standard presentation    algorithms of the ANU pq C program.",
-    "AcceptDate": "04/2002",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/anupq/releases/download/v3.2.6/anupq-3.2.6",
     "AutoDoc": {
@@ -448,7 +436,6 @@
     },
     "AvailabilityTest": null,
     "BannerFunction": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "07/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -532,18 +519,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/anupq"
     },
-    "Status": "accepted",
     "Subtitle": "ANU p-Quotient",
     "TestFile": "tst/testinstall.g",
     "Version": "3.2.6"
   },
   "atlasrep": {
     "AbstractHTML": "The package provides a <span class=\"pkgname\">GAP</span> interface to the <a href=\"http://atlas.math.rwth-aachen.de/Atlas/v3\">Atlas of Group Representations</a>",
-    "AcceptDate": "04/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/atlasrep-2.1.4",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "05/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -656,7 +640,6 @@
       }
     ],
     "README_URL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/README.md",
-    "Status": "accepted",
     "Subtitle": "A GAP Interface to the Atlas of Group Representations",
     "TestFile": "tst/testauto.g",
     "Version": "2.1.4"
@@ -777,19 +760,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/AutoDoc"
     },
-    "Status": "deposited",
     "Subtitle": "Generate documentation from GAP source code",
     "TestFile": "tst/testall.g",
     "Version": "2022.07.10"
   },
   "automata": {
     "AbstractHTML": "The <span class=\"pkgname\">Automata</span> package, as its name suggests, is package with algorithms to deal with automata.",
-    "AcceptDate": "09/2004",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/automata/releases/download/v1.15/automata-1.15",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
     "Date": "20/03/2022",
     "Dependencies": {
       "GAP": ">=4.8",
@@ -859,20 +839,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/automata"
     },
-    "Status": "accepted",
     "Subtitle": "A package on automata",
     "TestFile": "tst/testall.g",
     "Version": "1.15"
   },
   "automgrp": {
     "AbstractHTML": "The <span class=\"pkgname\">AutomGrp</span> package provides methods for computations with groups and semigroups generated by finite automata or given by wreath recursion, as well as with their finitely generated subgroups and elements.",
-    "AcceptDate": "03/2016",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/automgrp/releases/download/v1.3.2/automgrp-1.3.2",
     "Autoload": true,
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\n     ^                                    ___                   \n    / \\                                  /   \\                  \n   /   \\           _______  ___         ||        ___   __      \n  /_____\\   ||  ||    |    /   \\  |\\ /| ||   __ |/   | |  \\    \n /       \\  ||  ||    |   ||   || | V | ||   || |      |__/    \n/         \\  \\__/     |    \\___/  |   |  \\___/  |      |        \n                                                                \nLoading  AutomGrp 1.3.2 (Automata Groups and Semigroups)\nby Yevgen Muntyan (muntyan@fastmail.fm)\n   Dmytro Savchuk (http://savchuk.myweb.usf.edu/)\nHomepage: https://gap-packages.github.io/automgrp\n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
     "Date": "30/09/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -944,18 +921,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/automgrp"
     },
-    "Status": "accepted",
     "Subtitle": "Automata groups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
   },
   "autpgrp": {
     "AbstractHTML": "The <span class=\"pkgname\">AutPGrp</span> package introduces a new function to compute the automorphism group of a finite $p$-group. The underlying algorithm is a refinement of the methods described in O'Brien (1995). In particular, this implementation is more efficient in both time and space requirements and hence has a wider range of applications than the ANUPQ method. Our package is written in GAP code and it makes use of a number of methods from the GAP library such as the MeatAxe for matrix groups and permutation group functions. We have compared our method to the others available in GAP. Our package usually out-performs all but the method designed for finite abelian groups. We note that our method uses the small groups library in certain cases and hence our algorithm is more effective if the small groups library is installed.",
-    "AcceptDate": "09/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/autpgrp/releases/download/v1.11/autpgrp-1.11",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Derek F. Holt (Warwick)",
     "Date": "05/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1027,7 +1001,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/autpgrp"
     },
-    "Status": "accepted",
     "Subtitle": "Computing the Automorphism Group of a p-Group",
     "TestFile": "tst/testall.g",
     "Version": "1.11"
@@ -1108,7 +1081,6 @@
       }
     ],
     "README_URL": "https://www.math.rwth-aachen.de/~Browse/README",
-    "Status": "deposited",
     "Subtitle": "browsing applications and ncurses interface",
     "Version": "1.8.14"
   },
@@ -1204,14 +1176,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Categories, Algorithms, Programming",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-05"
   },
   "caratinterface": {
     "AbstractHTML": "This package provides <span class=\"pkgname\">GAP</span> interface routines to some of the stand-alone programs of <a href=\"https://lbfm-rwth.github.io/carat\">CARAT</a>, a package for the computation with crystallographic groups. CARAT is to a large extent complementary to the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">Cryst</span>. In particular, it provides routines for the computation of normalizers and conjugators of finite unimodular groups in GL(n,Z), and routines for the computation of Bravais groups, which are all missing in <span class=\"pkgname\">Cryst</span>. A catalog of Bravais groups up to dimension 6 is also provided.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CaratInterface/CaratInterface-2.3.4",
     "AvailabilityTest": null,
@@ -1220,7 +1190,6 @@
       "doc/manual.dvi",
       "carat.tgz"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1274,7 +1243,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/caratinterface"
     },
-    "Status": "accepted",
     "Subtitle": "Interface to CARAT, a crystallographic groups package",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -1339,18 +1307,15 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CddInterface"
     },
-    "Status": "deposited",
     "Subtitle": "Gap interface to Cdd package",
     "TestFile": "tst/testall.g",
     "Version": "2022.08.11"
   },
   "circle": {
     "AbstractHTML": "The <span class=\"pkgname\">Circle</span> package provides functionality for computations in adjoint groups of finite associative rings. It allows to construct circle objects that will respect the circle multiplication r*s=r+s+rs, create multiplicative groups, generated by such objects, and compute groups of elements, invertible with respect to this operation. Also it may serve as an example of extending the GAP system with new multiplicative objects.",
-    "AcceptDate": "01/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/circle/releases/download/v1.6.5/circle-1.6.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "27/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1417,7 +1382,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/circle"
     },
-    "Status": "accepted",
     "Subtitle": "Adjoint groups of finite rings",
     "TestFile": "tst/testall.g",
     "Version": "1.6.5"
@@ -1511,19 +1475,16 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/magmapresentations/"
     },
-    "Status": "deposited",
     "Subtitle": "Classical Group Presentations",
     "TestFile": "tst/testall.g",
     "Version": "1.22"
   },
   "cohomolo": {
     "AbstractHTML": "The <span class=\"pkgname\">cohomolo</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for computing Schur multipliers and covering groups of finite groups   and first and second cohomology groups of finite groups acting   on finite modules",
-    "AcceptDate": "01/1970",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/cohomolo/releases/download/v1.6.10/cohomolo-1.6.10",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "unknown (unknown)",
     "Date": "30/03/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -1581,18 +1542,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cohomolo"
     },
-    "Status": "accepted",
     "Subtitle": "Cohomology groups of finite groups on finite modules",
     "TestFile": "tst/testall.g",
     "Version": "1.6.10"
   },
   "congruence": {
     "AbstractHTML": "The <span class=\"pkgname\">Congruence </span> package provides functions to construct several types of canonical congruence subgroups in SL_2(Z), and also intersections of a finite number of such subgroups. Furthermore, it implements the algorithm for generating Farey symbols for congruence subgroups and using them to produce a system of independent generators for these subgroups",
-    "AcceptDate": "09/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/congruence/releases/download/v1.2.4/congruence-1.2.4",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Graham Ellis (Galway)",
     "Date": "27/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1679,14 +1637,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/congruence"
     },
-    "Status": "accepted",
     "Subtitle": "Congruence subgroups of SL(2,Integers)",
     "TestFile": "tst/testall.g",
     "Version": "1.2.4"
   },
   "corelg": {
     "AbstractHTML": "The package <span class=\"pkgname\">CoReLG</span> contains functionality for working with real semisimple Lie algebras.",
-    "AcceptDate": "01/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/corelg/releases/download/v1.56/corelg-1.56",
     "AutoDoc": {
@@ -1698,7 +1654,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "24/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1772,14 +1727,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/corelg"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with real Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.56"
   },
   "crime": {
     "AbstractHTML": "This package computes the cohomology rings of finite p-groups, induced maps, and Massey products.",
-    "AcceptDate": "10/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/crime/releases/download/v1.6/crime-1.6",
     "AutoDoc": {
@@ -1791,7 +1744,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\nThis is CRIME, Version 1.6\n\"Obviously crime pays, or there'd be no crime\".\n                                G. Gordon Liddy\n\n",
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "17/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1843,14 +1795,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crime"
     },
-    "Status": "accepted",
     "Subtitle": "A GAP Package to Calculate Group Cohomology and Massey Products",
     "TestFile": "tst/testall.g",
     "Version": "1.6"
   },
   "crisp": {
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">CRISP</span> provides algorithms for computing subgroups of finite soluble groups related to a group class <i>C</i>. In particular, it allows to compute <i>C</i>-radicals and <i>C</i>-injectors for Fitting classes (and Fitting sets) <i>C</i>, <i>C</i>-residuals for formations <i>C</i>, and <i>C</i>-projectors for Schunck classes <i>C</i>. In order to carry out these computations, the group class <i>C</i> must be represented by an algorithm which can decide membership in the group class.</p>  <p>Moreover, <span class=\"pkgname\">CRISP</span> contains algorithms for the computation of normal subgroups invariant under a prescribed set of automorphisms and belonging to a given group class.</p>  <p>This includes an improved method to compute the set of all normal subgroups of a finite soluble group, its characteristic subgroups, minimal normal subgroups and the socle and <i>p</i>-socles for given primes <i>p</i>.",
-    "AcceptDate": "12/2000",
     "ArchiveFormats": ".tar.bz2",
     "ArchiveURL": "http://www.icm.tu-bs.de/~bhoeflin/crisp/crisp-1.4.5",
     "Autoload": true,
@@ -1859,7 +1809,6 @@
     "BinaryFiles": [
       "doc/manual.pdf"
     ],
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "07/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1915,7 +1864,6 @@
       "Type": "git",
       "URL": "https://github.com/bh11/crisp.git"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with Radicals, Injectors, Schunck classes and Projectors",
     "TestFile": "tst/testall.g",
     "Version": "1.4.5"
@@ -1979,14 +1927,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crypting"
     },
-    "Status": "deposited",
     "Subtitle": "Hashes and Crypto in GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.10"
   },
   "cryst": {
     "AbstractHTML": "This package, previously known as <span class=\"pkgname\">CrystGAP</span>, provides a rich set of methods for the computation with affine crystallographic groups, in particular space groups. Affine crystallographic groups are fully supported both in representations acting from the right or from the left, the latter one being preferred by crystallographers. Functions to determine representatives of all space group types of a given dimension are also provided. Where necessary, <span class=\"pkgname\">Cryst</span> can also make use of functionality provided by the package <span class=\"pkgname\">CaratInterface</span>.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/Cryst/cryst-4.1.25",
     "AvailabilityTest": null,
@@ -1994,7 +1940,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2088,7 +2033,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cryst"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with crystallographic groups",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -2096,7 +2040,6 @@
   },
   "crystcat": {
     "AbstractHTML": "This package provides a catalog of crystallographic groups of dimensions 2, 3, and 4 which covers most of the data contained in the book <em>Crystallographic groups of four-dimensional space</em> by H. Brown, R. B&uuml;low, J. Neub&uuml;ser, H. Wondratschek, and H. Zassenhaus (John Wiley, New York, 1978). Methods for the computation with these groups are provided by the package <span class=\"pkgname\">Cryst</span>, which must be installed as well.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CrystCat/crystcat-1.1.10",
     "AvailabilityTest": null,
@@ -2104,7 +2047,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2167,7 +2109,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crystcat"
     },
-    "Status": "accepted",
     "Subtitle": "The crystallographic groups catalog",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -2280,19 +2221,16 @@
       }
     ],
     "README_URL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/ctbllib/README.md",
-    "Status": "deposited",
     "Subtitle": "The GAP Character Table Library",
     "TestFile": "tst/testauto.g",
     "Version": "1.3.4"
   },
   "cubefree": {
     "AbstractHTML": "The <span class=\"pkgname\">Cubefree</span> package contains methods to construct up to isomorphism the groups of a given (reasonable) cubefree order. The main function ConstructAllCFGroups(n) constructs all groups of a given cubefree order n. The function NumberCFGroups(n) counts all groups of a cubefree order n. Furthermore, IrreducibleSubgroupsOfGL(2,q) constructs the irreducible subgroups of GL(2,q), q=p^r, p>=5 prime, up to conjugacy and RewriteAbsolutelyIrreducibleMatrixGroup(G) rewrites the absolutely irreducible matrix group G (over a finite field) over a minimal subfield.",
-    "AcceptDate": "10/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/cubefree/releases/download/v1.19/cubefree-1.19",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "21/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2352,7 +2290,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cubefree"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing the Groups of a Given Cubefree Order",
     "TestFile": "tst/testall.g",
     "Version": "1.19"
@@ -2421,7 +2358,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/curlInterface"
     },
-    "Status": "deposited",
     "Subtitle": "Simple Web Access",
     "TestFile": "tst/testall.g",
     "Version": "2.2.3"
@@ -2502,7 +2438,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cvec"
     },
-    "Status": "deposited",
     "Subtitle": "Compact vectors over finite fields",
     "TestFile": "tst/testall.g",
     "Version": "2.7.6"
@@ -2603,7 +2538,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/datastructures"
     },
-    "Status": "deposited",
     "Subtitle": "Collection of standard data structures for GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.2.7"
@@ -2677,14 +2611,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/DeepThought"
     },
-    "Status": "deposited",
     "Subtitle": "This package provides functions for computations in finitely generated nilpotent groups based on the Deep Thought algorithm.",
     "TestFile": "tst/testall.g",
     "Version": "1.0.5"
   },
   "design": {
     "AbstractHTML": "<span class=\"pkgname\">DESIGN</span> is a package for constructing, classifying, partitioning, and studying block designs.",
-    "AcceptDate": "08/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/design/releases/download/v1.7/design-1.7",
     "AvailabilityTest": null,
@@ -2692,7 +2624,6 @@
       "doc/manual.dvi",
       "doc/manual.pdf"
     ],
-    "CommunicatedBy": "Akos Seress (Ohio State)",
     "Date": "18/03/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2755,14 +2686,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/design"
     },
-    "Status": "accepted",
     "Subtitle": "The Design Package for GAP",
     "TestFile": "tst/testall.g",
     "Version": "1.7"
   },
   "difsets": {
     "AbstractHTML": "The <span class=\"pkgname\">DifSets</span> package is a         <span class=\"pkgname\">GAP</span> package implementing an algorithm         for enumerating all difference sets up to equivalence in a group.",
-    "AcceptDate": "07/2019",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/dylanpeifer/difsets/releases/download/v2.3.1/difsets-2.3.1",
     "AutoDoc": {
@@ -2772,7 +2701,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alexander Hulpke (Colorado State)",
     "Date": "14/09/2019",
     "Dependencies": {
       "GAP": "4.9",
@@ -2830,7 +2758,6 @@
       "Type": "git",
       "URL": "https://github.com/dylanpeifer/difsets"
     },
-    "Status": "accepted",
     "Subtitle": "an algorithm for enumerating all difference sets in a group",
     "SupportEmail": "djp282@cornell.edu",
     "TestFile": "tst/testall.g",
@@ -3128,19 +3055,16 @@
       "Type": "git",
       "URL": "https://github.com/digraphs/Digraphs"
     },
-    "Status": "deposited",
     "Subtitle": "Graphs, digraphs, and multidigraphs in GAP",
     "TestFile": "tst/teststandard.g",
     "Version": "1.5.3"
   },
   "edim": {
     "AbstractHTML": "This package provides  a collection of functions for computing the Smith normal form of integer matrices and some related utilities.",
-    "AcceptDate": "08/1999",
     "ArchiveFormats": ".tar.bz2  .tar.gz   -win.zip",
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/EDIM-1.3.5",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Atkinson (St Andrews)",
     "Date": "13/08/2019",
     "Dependencies": {
       "ExternalConditions": [
@@ -3196,7 +3120,6 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/EDIM"
     },
-    "Status": "accepted",
     "Subtitle": "Elementary Divisors of Integer Matrices",
     "TestFile": "tst/edim.tst",
     "Version": "1.3.5"
@@ -3282,7 +3205,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/example"
     },
-    "Status": "deposited",
     "Subtitle": "Example/Template of a GAP Package",
     "SupportEmail": "obk1@st-andrews.ac.uk",
     "TestFile": "tst/testall.g",
@@ -3396,14 +3318,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Examples for the GAP Package homalg",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "factint": {
     "AbstractHTML": "\nThis package provides routines for factoring integers, in particular:\n<ul>\n  <li>Pollard's <em>p</em>-1</li>\n  <li>Williams' <em>p</em>+1</li>\n  <li>Elliptic Curves Method (ECM)</li>\n  <li>Continued Fraction Algorithm (CFRAC)</li>\n  <li>Multiple Polynomial Quadratic Sieve (MPQS)</li>\n</ul>\nIt also provides access to Richard P. Brent's tables of factors of integers of the form <em>b</em>^<em>k</em> +/- 1.\n",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/FactInt/releases/download/v1.6.3/FactInt-1.6.3",
     "AutoDoc": {
@@ -3414,7 +3334,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Atkinson (St. Andrews)",
     "Date": "15/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3485,7 +3404,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FactInt"
     },
-    "Status": "accepted",
     "Subtitle": "Advanced Methods for Factoring Integers",
     "TestFile": "tst/testall.g",
     "Version": "1.6.3"
@@ -3552,19 +3470,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ferret"
     },
-    "Status": "deposited",
     "Subtitle": "Backtrack Search in Permutation Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.0.8"
   },
   "fga": {
     "AbstractHTML": "The <span class=\"pkgname\">FGA</span> package installs methods for    computations with finitely generated subgroups of free groups and    provides a presentation for their automorphism groups.",
-    "AcceptDate": "05/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "http://www.icm.tu-bs.de/ag_algebra/software/FGA/FGA-1.4.0",
     "Autoload": true,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
     "Date": "23/03/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3611,14 +3526,12 @@
       "Type": "git",
       "URL": "https://github.com/chsievers/fga"
     },
-    "Status": "accepted",
     "Subtitle": "Free Group Algorithms",
     "TestFile": "tst/testall.g",
     "Version": "1.4.0"
   },
   "fining": {
     "AbstractHTML": "<span class=\"pkgname\">FinInG</span> is a package for computation in Finite Incidence Geometry. It provides users with the basic tools to work in  various areas of finite geometry from the realms of projective spaces to the flat  lands of generalised polygons. The algebraic power of GAP is employed, particularly  in its facility with matrix and permutation groups.",
-    "AcceptDate": "11/2017",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/FinInG/releases/download/v1.5/fining-1.5",
     "AutoDoc": {
@@ -3632,7 +3545,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "-------------------------------------------------------------------------------\n         ______________       ________      _________   __________ __          \n         ___  ____/__(_)__________  _/________  ____/   __<  /_  // /          \n         __  /_   __  /__  __ __  / __  __   / __     __  /_  // /_          \n         _  __/   _  / _  / / /_/ /  _  / / / /_/ /     _  /_/__  __/          \n         /_/      /_/  /_/ /_//___/  /_/ /_/____/      /_/_(_)/_/             \n-------------------------------------------------------------------------------\nLoading  FinInG 1.5 (Finite Incidence Geometry) \nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Anton Betten (http://www.math.colostate.edu/~betten)\n   Philippe Cara (http://homepages.vub.ac.be/~pcara)\n   Jan De Beule (http://www.debeule.eu)\n   Michel Lavrauw (http://people.sabanciuniv.edu/~mlavrauw/)\n   Max Neunhoeffer (http://www-groups.mcs.st-and.ac.uk/~neunhoef/)\nFor help, type: ?FinInG \n---------------------------------------------------------------------\n",
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
     "Date": "10/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3772,7 +3684,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FinInG"
     },
-    "Status": "accepted",
     "Subtitle": "Finite Incidence Geometry",
     "TestFile": "tst/testall.g",
     "Version": "1.5"
@@ -3837,18 +3748,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/float"
     },
-    "Status": "deposited",
     "Subtitle": "Integration of mpfr, mpfi, mpc, fplll and cxsc in GAP",
     "TestFile": "tst/testall.g",
     "Version": "1.0.3"
   },
   "format": {
     "AbstractHTML": "This package provides functions for computing with formations of finite solvable groups.",
-    "AcceptDate": "12/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/format/releases/download/v1.4.3/format-1.4.3",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3916,14 +3824,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/format"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with formations of finite solvable groups.",
     "TestFile": "tst/testall.g",
     "Version": "1.4.3"
   },
   "forms": {
     "AbstractHTML": "This package can be used for work with sesquilinear and quadratic forms on finite vector spaces; objects that are used to describe polar spaces and classical groups.",
-    "AcceptDate": "03/2009",
     "ArchiveFormats": ".tar.gz .zip .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/forms/releases/download/v1.2.8/forms-1.2.8",
     "AutoDoc": {
@@ -3933,7 +3839,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "---------------------------------------------------------------------\nLoading 'Forms' 1.2.8 (09/07/2022)\nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Jan De Beule (http://www.debeule.eu)\nFor help, type: ?Forms \n---------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (London)",
     "Date": "09/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4004,18 +3909,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/forms"
     },
-    "Status": "accepted",
     "Subtitle": "Sesquilinear and Quadratic",
     "TestFile": "tst/testall.g",
     "Version": "1.2.8"
   },
   "fplsa": {
     "AbstractHTML": "The <span class=\"pkgname\">FPLSA</span> package uses    the authors' C program (version 4.0) that implements    a Lie Todd-Coxeter method for converting    finitely presented Lie algebras into isomorphic    structure constant algebras.    This is called via the GAP function IsomorphismSCTableAlgebra.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/FPLSA/releases/download/v1.2.5/FPLSA-1.2.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Steve Linton (St Andrews)",
     "Date": "10/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4077,7 +3979,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FPLSA"
     },
-    "Status": "accepted",
     "Subtitle": "Finitely Presented Lie Algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.2.5"
@@ -4096,7 +3997,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "Loading FR 2.4.10 ...\n",
-    "CommunicatedBy": "G\u00f6tz Pfeiffer (NUI Galway)",
     "Date": "10/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4175,7 +4075,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/fr"
     },
-    "Status": "deposited",
     "Subtitle": "Computations with functionally recursive groups",
     "TestFile": "tst/testall.g",
     "Version": "2.4.10"
@@ -4249,7 +4148,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/Francy"
     },
-    "Status": "deposited",
     "Subtitle": "Framework for Interactive Discrete Mathematics",
     "TestFile": "tst/testall.g",
     "Version": "1.2.4"
@@ -4344,18 +4242,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/fwtree"
     },
-    "Status": "deposited",
     "Subtitle": "Computing trees related to some pro-p-groups of finite width",
     "TestFile": "tst/testall.g",
     "Version": "1.3"
   },
   "gapdoc": {
     "AbstractHTML": "This package contains a definition of a structure for <span class='pkgname'>GAP</span> (package) documentation, based on XML. It also contains  conversion programs for producing text-, PDF- or HTML-versions of such documents, with hyperlinks if possible.",
-    "AcceptDate": "10/2006",
     "ArchiveFormats": ".tar.bz2 .tar.gz -win.zip",
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.6",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Steve Linton (St Andrews)",
     "Date": "01/07/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -4436,7 +4331,6 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/GAPDoc"
     },
-    "Status": "accepted",
     "Subtitle": "A Meta Package for GAP Documentation",
     "TestFile": "tst/test.tst",
     "Version": "1.6.6"
@@ -4528,7 +4422,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Extended Gauss functionality for GAP",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-04"
@@ -4617,14 +4510,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Gauss functionality for the homalg project",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "gbnp": {
     "AbstractHTML": "The <span class=\"pkgname\">GBNP</span> package provides algorithms for    computing Grobner bases of noncommutative polynomials with coefficients    from a field implemented in <span class=\"pkgname\">GAP</span> and with    respect to the \"total degree first then lexicographical\" ordering.    Further provided are some variations, such as a weighted and truncated    version and a tracing facility. The word \"algorithm\" is to be    interpreted loosely here: in general one cannot expect such an algorithm    to terminate, as it would imply solvability of the word problem for    finitely presented (semi)groups.",
-    "AcceptDate": "05/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/gbnp/releases/download/v1.0.5/gbnp-1.0.5",
     "AutoDoc": {
@@ -4639,7 +4530,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alexander Hulpke (Fort Collins, CO)",
     "Date": "09/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4707,7 +4597,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/gbnp"
     },
-    "Status": "accepted",
     "Subtitle": "computing Gr\u00f6bner bases of noncommutative polynomials",
     "TestFile": "tst/testall.g",
     "Version": "1.0.5"
@@ -4784,7 +4673,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Implementations of generalized morphisms for the CAP project",
     "TestFile": "tst/testall.g",
     "Version": "2022.05-01"
@@ -4881,7 +4769,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/genss"
     },
-    "Status": "deposited",
     "Subtitle": "Generic Schreier-Sims",
     "TestFile": "tst/testall.g",
     "Version": "1.6.7"
@@ -5034,7 +4921,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
@@ -5180,14 +5066,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Endow Commutative Rings with an Abelian Grading",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "grape": {
     "AbstractHTML": "<span class=\"pkgname\">GRAPE</span> is a package for computing with graphs and groups, and is primarily designed for constructing and analysing graphs related to groups, finite geometries, and designs.",
-    "AcceptDate": "07/1993",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/grape/releases/download/v4.8.5/grape-4.8.5",
     "AvailabilityTest": null,
@@ -5197,7 +5081,6 @@
       "nauty22/nug.pdf",
       "bin/i686-pc-cygwin-gcc-default32/dreadnautB.exe"
     ],
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "26/03/2021",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5246,14 +5129,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/grape"
     },
-    "Status": "accepted",
     "Subtitle": "GRaph Algorithms using PErmutation groups",
     "TestFile": "tst/testall.g",
     "Version": "4.8.5"
   },
   "groupoids": {
     "AbstractHTML": "The groupoids package provides a collection of functions for computing with finite groupoids, graph of groups, and graphs of groupoids. These are based on the more basic structures of magmas with objects and their mappings. It provides functions for normal forms of elements in Free Products with Amalgamation and in HNN extensions. Up until April 2017 this package was named Gpd.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/groupoids/releases/download/v1.71/groupoids-1.71",
     "AutoDoc": {
@@ -5266,7 +5147,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading groupoids 1.71 (algorithms for finite groupoids)\nby Emma Moore and Chris Wensley (https://github.com/cdwensley)\n--------------------------------------------------------------\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "07/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5347,7 +5227,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/groupoids"
     },
-    "Status": "accepted",
     "Subtitle": "Calculations with finite groupoids and their homomorphisms",
     "SupportEmail": "c.d.wensley@bangor.ac.uk",
     "TestFile": "tst/testall.g",
@@ -5355,11 +5234,9 @@
   },
   "grpconst": {
     "AbstractHTML": "The <span class=\"pkgname\">GrpConst</span> package contains methods to construct up to isomorphism the groups of a given order. The FrattiniExtensionMethod constructs all soluble groups of a given order. On request it gives only those that are (or are not) nilpotent or supersolvable or that do (or do not) have normal Sylow subgroups for some given set of primes. The CyclicSplitExtensionMethod constructs all groups having a normal Sylow subgroup for orders of the type p^n *q. The method relies on the availability of a list of all groups of order p^n. The UpwardsExtensions algorithm takes as input a permutation group G and a positive integer s and returns a list of permutation groups, one for each extension of G by a soluble group of order a divisor of s. This method can used to construct the non-solvable groups of a given order by taking the perfect groups of certain orders as input for G. The programs in this package have been used to construct a large part of the Small Groups library.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/grpconst/releases/download/v2.6.2/grpconst-2.6.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5438,7 +5315,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/grpconst"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing the Groups of a Given Order",
     "TestFile": "tst/testall.g",
     "Version": "2.6.2"
@@ -5539,20 +5415,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/guarana"
     },
-    "Status": "deposited",
     "Subtitle": "Applications of Lie methods for computations with infinite polycyclic groups",
     "TestFile": "tst/testall.g",
     "Version": "0.96.3"
   },
   "guava": {
     "AbstractHTML": "<span class=\"pkgname\">GUAVA</span> is a <span class=\"pkgname\">GAP</span> package for computing with codes. <span class=\"pkgname\">GUAVA</span> can construct unrestricted (non-linear), linear and cyclic codes; transform one code into another (for example by puncturing); construct a new code from two other codes (using direct sums for example); perform decoding/error-correction; and can calculate important data of codes (such as the minumim distance or covering radius) quickly. Limited ability to compute algebraic geometric codes.",
-    "AcceptDate": "02/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/guava/releases/download/v3.16/guava-3.16",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\n   ____                          |\n  /            \\           /   --+--  Version 3.16\n /      |    | |\\\\        //|    |\n|    _  |    | | \\\\      // |     the GUAVA Group\n|     \\ |    | |--\\\\    //--|     \n \\     ||    | |   \\\\  //   |     \n  \\___/  \\___/ |    \\\\//    |      \n                                  \n\n",
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "24/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5702,19 +5575,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/guava"
     },
-    "Status": "accepted",
     "Subtitle": "a GAP package for computing with error-correcting codes",
     "TestFile": "tst/guava.tst",
     "Version": "3.16"
   },
   "hap": {
     "AbstractHTML": "This package provides some functions for group cohomology and algebraic topology. ",
-    "AcceptDate": "03/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/hap/releases/download/v1.47/hap-1.47",
     "AvailabilityTest": null,
     "BannerString": "Loading HAP 1.47 ...\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "14/08/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -5855,7 +5725,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hap"
     },
-    "Status": "accepted",
     "Subtitle": "Homological Algebra Programming",
     "TestFile": "tst/testquick.g",
     "Version": "1.47"
@@ -5971,7 +5840,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hapcryst"
     },
-    "Status": "deposited",
     "Subtitle": "A HAP extension for crystallographic groups",
     "TestFile": "tst/testall.g",
     "Version": "0.1.15"
@@ -6043,7 +5911,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hecke"
     },
-    "Status": "deposited",
     "Subtitle": "Calculating decomposition matrices of Hecke algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.5.3"
@@ -6147,7 +6014,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/HeLP"
     },
-    "Status": "deposited",
     "Subtitle": "Hertweck-Luthar-Passi method.",
     "TestFile": "tst/testall.g",
     "Version": "3.5"
@@ -6245,7 +6111,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homological algebra meta-package for computable Abelian categories",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
@@ -6392,14 +6257,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A window to the outer world",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "idrel": {
     "AbstractHTML": "IdRel is a package for computing the identities among relations of a group presentation using rewriting, logged rewriting, monoid polynomials, module polynomials and Y-sequences.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/idrel/releases/download/v2.44/idrel-2.44",
     "AutoDoc": {
@@ -6412,7 +6275,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading IdRel 2.44 (Identities among Relations)\nby Anne Heyworth and Chris Wensley (https://github.com/cdwensley)\n-----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "04/06/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -6478,7 +6340,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/idrel"
     },
-    "Status": "accepted",
     "Subtitle": "Identities among relations",
     "TestFile": "tst/testall.g",
     "Version": "2.44"
@@ -6575,7 +6436,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/images"
     },
-    "Status": "deposited",
     "Subtitle": "Minimal and Canonical images",
     "TestFile": "tst/testall.g",
     "Version": "1.3.1"
@@ -6646,7 +6506,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/intpic"
     },
-    "Status": "deposited",
     "Subtitle": "A package for drawing integers",
     "TestFile": "tst/testall.g",
     "Version": "0.3.0"
@@ -6726,7 +6585,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/io"
     },
-    "Status": "deposited",
     "Subtitle": "Bindings for low level C library I/O routines",
     "TestFile": "tst/testall.g",
     "Version": "4.7.2"
@@ -6846,20 +6704,17 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "IO capabilities for the homalg project",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
   },
   "irredsol": {
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">IRREDSOL</span> provides a library of all irreducible soluble subgroups of <i>GL(n,q)</i>, up to conjugacy, for <i>q<sup>n</sup></i> up to 2^24-1, and a library of the primitive soluble groups of degree up to 2^24-1.",
-    "AcceptDate": "08/2006",
     "ArchiveFormats": ".tar.bz2",
     "ArchiveURL": "https://github.com/bh11/irredsol/releases/latest/download/irredsol-1.4.3",
     "Autoload": true,
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------------\n                          IRREDSOL Version 1.4.3\n  A library of irreducible soluble linear groups over finite fields\n                and of finite primivite soluble groups\n                         by Burkhard H\u00f6fling\n----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "01/07/2021",
     "Dependencies": {
       "ExternalConditions": [],
@@ -6921,7 +6776,6 @@
       "Type": "git",
       "URL": "https://github.com/bh11/irredsol.git"
     },
-    "Status": "accepted",
     "Subtitle": "A library of irreducible soluble linear groups over finite fields and of finite primivite soluble groups",
     "TestFile": "tst/testall.g",
     "TextBinaryFilesPatterns": [
@@ -6932,13 +6786,11 @@
   },
   "itc": {
     "AbstractHTML": "This <span class=\"pkgname\">GAP</span> package provides    access to interactive Todd-Coxeter computations    with finitely presented groups.",
-    "AcceptDate": "03/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/itc/releases/download/v1.5.1/itc-1.5.1",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\n          Loading  ITC 1.5.1  (Interactive Todd-Coxeter)\n            by V. Felsch, L. Hippe, and J. Neubueser\n              (Volkmar.Felsch@math.rwth-aachen.de)\n\n",
-    "CommunicatedBy": "Edmund F. Robertson (St Andrews)",
     "Date": "01/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7015,7 +6867,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/itc"
     },
-    "Status": "accepted",
     "Subtitle": "Interactive Todd-Coxeter",
     "Version": "1.5.1"
   },
@@ -7072,7 +6923,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/json"
     },
-    "Status": "deposited",
     "Subtitle": "Reading and Writing JSON",
     "TestFile": "tst/testall.g",
     "Version": "2.1.0"
@@ -7224,7 +7074,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/JupyterKernel"
     },
-    "Status": "deposited",
     "Subtitle": "Jupyter kernel written in GAP",
     "TestFile": "tst/testinstall.g",
     "Version": "1.4.1"
@@ -7294,7 +7143,6 @@
       "Type": "git",
       "URL": "https://github.com/nathancarter/jupyterviz"
     },
-    "Status": "deposited",
     "Subtitle": "Visualization Tools for Jupyter and the GAP REPL",
     "SupportEmail": "ncarter@bentley.edu",
     "TestFile": "tst/testall.g",
@@ -7302,7 +7150,6 @@
   },
   "kan": {
     "AbstractHTML": "The Kan package provides functions for the computation of normal forms   of representatives of double cosets of finitely presented groups.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/kan/releases/download/v1.34/kan-1.34",
     "AutoDoc": {
@@ -7315,7 +7162,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading Kan 1.34 (computing with Kan extensions)\nby Anne Heyworth and Chris Wensley (https://github.com/cdwensley)\n-----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "13/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7384,14 +7230,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/kan"
     },
-    "Status": "accepted",
     "Subtitle": "including double coset rewriting systems",
     "TestFile": "tst/testall.g",
     "Version": "1.34"
   },
   "kbmag": {
     "AbstractHTML": "The <span class=\"pkgname\">kbmag</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for running the Knuth-Bendix completion program on finite semigroup,   monoid or group presentations, and for attempting to compute automatic   structures of finitely presented groups",
-    "AcceptDate": "07/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/kbmag/releases/download/v1.5.9/kbmag-1.5.9",
     "AutoDoc": {
@@ -7403,7 +7247,6 @@
     },
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Oregon)",
     "Date": "07/07/2019",
     "Dependencies": {
       "ExternalConditions": [
@@ -7459,18 +7302,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/kbmag"
     },
-    "Status": "accepted",
     "Subtitle": "Knuth-Bendix on Monoids and Automatic Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.5.9"
   },
   "laguna": {
     "AbstractHTML": "The <span class=\"pkgname\">LAGUNA</span> package replaces the <span class=\"pkgname\">LAG</span> package and provides functionality for calculation of the normalized unit group of the modular group algebra of the finite p-group and for investigation of Lie algebra associated with group algebras and other associative algebras.",
-    "AcceptDate": "06/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/laguna/releases/download/v3.9.5/laguna-3.9.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "27/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7557,14 +7397,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/laguna"
     },
-    "Status": "accepted",
     "Subtitle": "Lie AlGebras and UNits of group Algebras",
     "TestFile": "tst/testall.g",
     "Version": "3.9.5"
   },
   "liealgdb": {
     "AbstractHTML": "",
-    "AcceptDate": "09/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liealgdb/releases/download/v2.2.1/liealgdb-2.2.1",
     "AutoDoc": {
@@ -7575,7 +7413,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "07/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7651,19 +7488,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liealgdb"
     },
-    "Status": "accepted",
     "Subtitle": "A database of Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "2.2.1"
   },
   "liepring": {
     "AbstractHTML": "",
-    "AcceptDate": "09/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liepring/releases/download/v2.7/liepring-2.7",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading  LiePRing 2.7\nby Bettina Eick and Michael Vaughan-Lee \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (London)",
     "Date": "05/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7728,14 +7562,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liepring"
     },
-    "Status": "accepted",
     "Subtitle": "Database and algorithms for Lie p-rings",
     "TestFile": "tst/testall.g",
     "Version": "2.7"
   },
   "liering": {
     "AbstractHTML": "The package <span class=\"pkgname\">LieRing</span> contains                  functionality for working with finitely presented Lie rings and the Lazard correspondence.",
-    "AcceptDate": "12/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liering/releases/download/v2.4.2/liering-2.4.2",
     "AutoDoc": {
@@ -7747,7 +7579,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "LieRing\n a package for working with Lie rings \n by Serena Cical\u00f2 and Willem de Graaf\n",
-    "CommunicatedBy": "Max Neunhoeffer (Cologne)",
     "Date": "10/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7812,7 +7643,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liering"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with finitely presented Lie rings",
     "TestFile": "tst/testall.g",
     "Version": "2.4.2"
@@ -7906,7 +7736,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Category of Matrices over a Field for CAP",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
@@ -8010,14 +7839,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A Package for Localization of Polynomial Rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "loops": {
     "AbstractHTML": "The LOOPS package provides researchers in nonassociative algebra with a computational tool that integrates standard notions of loop theory with libraries of loops and group-theoretical algorithms of GAP. The package also expands GAP toward nonassociative structures.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/loops/releases/download/v3.4.2/loops-3.4.2",
     "AutoDoc": {
@@ -8029,7 +7856,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "31/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8100,20 +7926,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/loops"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with quasigroups and loops in GAP",
     "TestFile": "tst/testall.g",
     "Version": "3.4.2"
   },
   "lpres": {
     "AbstractHTML": "The LPRES Package defines new GAP objects to work with L-presented groups, namely groups given by a finite generating set and a possibly-infinite set of relations given as iterates of finitely many seed relations by a finite set of endomorphisms. The package implements nilpotent quotient, Todd-Coxeter and Reidemeister-Schreier algorithms for L-presented groups.",
-    "AcceptDate": "09/2018",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/lpres/releases/download/v1.0.3/lpres-1.0.3",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading lpres 1.0.3 ...\n",
-    "CommunicatedBy": "Alexander Konovalov (St Andrews)",
     "Date": "20/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8203,7 +8026,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/lpres"
     },
-    "Status": "accepted",
     "Subtitle": "Nilpotent Quotients of L-Presented Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.0.3"
@@ -8297,7 +8119,6 @@
       "Type": "git",
       "URL": "https://github.com/MWhybrow92/MajoranaAlgebras"
     },
-    "Status": "dev",
     "Subtitle": "A package for constructing Majorana algebras and representations",
     "SupportEmail": "mlw10@ic.ac.uk",
     "TestFile": "tst/testall.g",
@@ -8305,11 +8126,9 @@
   },
   "mapclass": {
     "AbstractHTML": "The <span class=\"pkgname\">MapClass</span> package calculates the    mapping class group orbits for a given finite group.",
-    "AcceptDate": "11/2011",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/MapClass/releases/download/v1.4.5/MapClass-1.4.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "17/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8376,7 +8195,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/MapClass"
     },
-    "Status": "accepted",
     "Subtitle": "A Package For Mapping Class Orbit Computation",
     "TestFile": "tst/testall.g",
     "Version": "1.4.5"
@@ -8458,7 +8276,6 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/matgrp/"
     },
-    "Status": "deposited",
     "Subtitle": "Matric Group Interface Routines",
     "TestFile": "tst/testall.g",
     "Version": "0.70"
@@ -8567,20 +8384,17 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Matrices for the homalg project",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "modisom": {
     "AbstractHTML": "The <span class=\"pkgname\">ModIsom</span> package contains various methods for computing with nilpotent associative algebras. In particular, it contains a method to determine the automorphism group and to test isomorphis of such algebras over finite fields and of modular group algebras of finite p-groups, and it contains a nilpotent quotient algorithm for finitely presented associative algebras and a method to determine Kurosh algebras.",
-    "AcceptDate": "11/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/modisom/releases/download/v2.5.3/modisom-2.5.3",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading ModIsom 2.5.3... \n",
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
     "Date": "09/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8650,7 +8464,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/modisom"
     },
-    "Status": "accepted",
     "Subtitle": "Computing automorphisms and checking isomorphisms for modular group algebras of finite p-groups",
     "TestFile": "tst/testall.g",
     "Version": "2.5.3"
@@ -8744,7 +8557,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Category R-pres for CAP",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
@@ -8885,7 +8697,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homalg based package for the Abelian category of finitely presented modules over computable rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
@@ -8991,7 +8802,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Monoidal and monoidal (co)closed categories",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
@@ -9089,20 +8899,17 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/NConvex"
     },
-    "Status": "deposited",
     "Subtitle": "A Gap package to perform polyhedral computations",
     "TestFile": "tst/testall.g",
     "Version": "2020.11-04"
   },
   "nilmat": {
     "AbstractHTML": "The <span class=\"pkgname\">Nilmat</span> package contains methods for checking whether a finitely generated matrix group over a finite field or the field of rational numbers is nilpotent, methods for computing with such nilpotent matrix groups and methods for constructing important classes of such nilpotent matrix groups.",
-    "AcceptDate": "08/2007",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/nilmat/releases/download/v1.4.2/nilmat-1.4.2",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading Nilmat 1.4.2...\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "05/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9179,14 +8986,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/nilmat"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with nilpotent matrix groups",
     "TestFile": "tst/testall.g",
     "Version": "1.4.2"
   },
   "nock": {
     "AbstractHTML": "The <span class=\"pkgname\">NoCK</span> package    is used for computing Tolzanos's obstruction    for compact Clifford-Klein forms",
-    "AcceptDate": "07/2019",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/NoCK/releases/download/v1.5/NoCK-1.5",
     "AutoDoc": {
@@ -9198,7 +9003,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nNoCK Package 1.5\nby Maciej Boche\u0144ski, Piotr Jastrz\u0119bski, Anna Szczepkowska, Aleksy Tralle, Artur Woike.\n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "30/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9304,7 +9108,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/NoCK"
     },
-    "Status": "accepted",
     "Subtitle": "Computing obstruction for the existence of compact Clifford-Klein form",
     "SupportEmail": "piojas@matman.uwm.edu.pl",
     "TestFile": "tst/testall.g",
@@ -9378,14 +9181,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/NormalizInterface"
     },
-    "Status": "deposited",
     "Subtitle": "GAP wrapper for Normaliz",
     "TestFile": "tst/testall.g",
     "Version": "1.3.4"
   },
   "nq": {
     "AbstractHTML": "This package provides access to the ANU nilpotent quotient program for computing nilpotent factor groups of finitely presented groups.",
-    "AcceptDate": "01/2003",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/nq/releases/download/v2.5.8/nq-2.5.8",
     "AutoDoc": {
@@ -9396,7 +9197,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "Loading nq 2.5.8 (Nilpotent Quotient Algorithm)\n  by Werner Nickel\n  maintained by Max Horn (horn@mathematik.uni-kl.de)\n",
-    "CommunicatedBy": "Joachim Neub\u00fcser (RWTH Aachen)",
     "Date": "04/04/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -9468,19 +9268,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/nq"
     },
-    "Status": "accepted",
     "Subtitle": "Nilpotent Quotients of Finitely Presented Groups",
     "TestFile": "tst/testall.g",
     "Version": "2.5.8"
   },
   "numericalsgps": {
     "AbstractHTML": "The <span class=\"pkgname\">NumericalSgps</span> package, is a package to compute with numerical semigroups.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz .zip",
     "ArchiveURL": "https://github.com/gap-packages/numericalsgps/releases/download/v1.3.1/NumericalSgps-1.3.1",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading  NumericalSgps 1.3.1\nFor help, type: ?NumericalSgps: \nTo gain profit from other packages, please refer to chapter\n'External Packages' in the manual, or type: ?NumSgpsUse \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "27/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9665,19 +9462,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/numericalsgps"
     },
-    "Status": "accepted",
     "Subtitle": "A package for numerical semigroups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.1"
   },
   "openmath": {
     "AbstractHTML": "This package provides an <a href=\"http://www.openmath.org/\">OpenMath</a> phrasebook for <span class=\"pkgname\">GAP</span>. This package allows <span class=\"pkgname\">GAP</span> users to import and export mathematical objects encoded in OpenMath, for the purpose of exchanging them with other applications that are OpenMath enabled.",
-    "AcceptDate": "08/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/openmath/releases/download/v11.5.1/OpenMath-11.5.1",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "29/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9759,7 +9553,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/openmath"
     },
-    "Status": "accepted",
     "Subtitle": "OpenMath functionality in GAP",
     "TestFile": "tst/testall.g",
     "Version": "11.5.1"
@@ -9859,7 +9652,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/orb"
     },
-    "Status": "deposited",
     "Subtitle": "Methods to enumerate orbits",
     "TestFile": "tst/testall.g",
     "Version": "4.8.5"
@@ -9921,7 +9713,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/PackageManager"
     },
-    "Status": "deposited",
     "Subtitle": "Easily download and install GAP packages",
     "TestFile": "tst/test-without-texlive.g",
     "Version": "1.3"
@@ -10013,18 +9804,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/PatternClass"
     },
-    "Status": "deposited",
     "Subtitle": "A permutation pattern class package",
     "TestFile": "tst/testall.g",
     "Version": "2.4.2"
   },
   "permut": {
     "AbstractHTML": "This package provides functions for computing with permutability in finite groups.",
-    "AcceptDate": "04/2014",
     "ArchiveFormats": ".tar.gz .tar.bz2 .zip",
     "ArchiveURL": "https://github.com/gap-packages/permut/releases/download/v2.0.4/permut-2.0.4",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alice Niemeyer (Perth)",
     "Date": "27/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10104,7 +9892,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/permut"
     },
-    "Status": "accepted",
     "Subtitle": "A package to deal with permutability in finite groups",
     "SupportEmail": "Ramon.Esteban@uv.es",
     "TestFile": "tst/testall.g",
@@ -10112,7 +9899,6 @@
   },
   "polenta": {
     "AbstractHTML": "The <span class=\"pkgname\">Polenta</span> package provides  methods to compute polycyclic presentations of matrix groups (finite or infinite). As a by-product, this package gives some functionality to compute certain module series for modules of solvable groups. For example, if G is a rational polycyclic matrix group, then we can compute the radical series of the natural Q[G]-module Q^d.",
-    "AcceptDate": "08/2005",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/polenta/releases/download/v1.3.10/polenta-1.3.10",
     "AutoDoc": {
@@ -10123,7 +9909,6 @@
     },
     "Autoload": true,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "29/03/2022",
     "Dependencies": {
       "GAP": ">= 4.7",
@@ -10200,14 +9985,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polenta"
     },
-    "Status": "accepted",
     "Subtitle": "Polycyclic presentations for matrix groups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.10"
   },
   "polycyclic": {
     "AbstractHTML": "This package provides various algorithms for computations with polycyclic groups defined by polycyclic presentations.",
-    "AcceptDate": "01/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/polycyclic/releases/download/v2.16/polycyclic-2.16",
     "AutoDoc": {
@@ -10217,7 +10000,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "25/07/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10318,7 +10100,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polycyclic"
     },
-    "Status": "accepted",
     "Subtitle": "Computation with polycyclic groups",
     "TestFile": "tst/testall.g",
     "Version": "2.16"
@@ -10394,7 +10175,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polymaking"
     },
-    "Status": "deposited",
     "Subtitle": "Interfacing the geometry software polymake",
     "TestFile": "tst/testall.g",
     "Version": "0.8.6"
@@ -10485,7 +10265,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/primgrp"
     },
-    "Status": "deposited",
     "Subtitle": "GAP Primitive Permutation Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "3.4.2"
@@ -10547,7 +10326,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/profiling"
     },
-    "Status": "deposited",
     "Subtitle": "Line by line profiling and code coverage for GAP",
     "TestFile": "tst/testall.g",
     "Version": "2.5.0"
@@ -10621,14 +10399,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/qpa"
     },
-    "Status": "deposited",
     "Subtitle": "Quivers and Path Algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.34"
   },
   "quagroup": {
     "AbstractHTML": "The package <span class=\"pkgname\">QuaGroup</span> contains                  functionality for working with quantized enveloping algebras                 of finite-dimensional semisimple Lie algebras.",
-    "AcceptDate": "10/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/quagroup/releases/download/v1.8.3/quagroup-1.8.3",
     "AutoDoc": {
@@ -10639,7 +10415,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "     |                                                                 \n     |          QuaGroup 1.8.3\n     |                                                                 \n-----------     A package for dealing with quantized enveloping algebras\n     |                                                                 \n     |          Willem de Graaf                                        \n     |          degraaf@science.unitn.it                               \n\n",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "10/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10693,19 +10468,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/quagroup"
     },
-    "Status": "accepted",
     "Subtitle": "Computations with quantum groups",
     "TestFile": "tst/testall.g",
     "Version": "1.8.3"
   },
   "radiroot": {
     "AbstractHTML": "The <span class=\"pkgname\">RadiRoot</span> package installs a method to    display the roots of a rational polynomial as radicals if it is solvable.",
-    "AcceptDate": "02/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/radiroot/releases/download/v2.9/radiroot-2.9",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St Andrews)",
     "Date": "01/03/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -10765,14 +10537,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/radiroot"
     },
-    "Status": "accepted",
     "Subtitle": "Roots of a Polynomial as Radicals",
     "TestFile": "tst/testall.g",
     "Version": "2.9"
   },
   "rcwa": {
     "AbstractHTML": "This package provides implementations of algorithms and methods for computation in certain infinite permutation groups.",
-    "AcceptDate": "04/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/rcwa/releases/download/v4.7.0/rcwa-4.7.0",
     "AutoDoc": {
@@ -10784,7 +10554,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "\nLoading RCWA 4.7.0 ([R]esidue-[C]lass-[W]ise [A]ffine groups)\n  by Stefan Kohl, sk239@st-andrews.ac.uk.\nSee ?RCWA:About for information about the package.\n\n",
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10860,18 +10629,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/rcwa"
     },
-    "Status": "accepted",
     "Subtitle": "Residue-Class-Wise Affine Groups",
     "TestFile": "tst/testall.g",
     "Version": "4.7.0"
   },
   "rds": {
     "AbstractHTML": "This package provides functions for the complete enumeration of relative difference sets.",
-    "AcceptDate": "02/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/rds/releases/download/v1.8/rds-1.8",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
     "Date": "21/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10936,7 +10702,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/rds"
     },
-    "Status": "accepted",
     "Subtitle": "A package for searching relative difference sets",
     "TestFile": "tst/testall.g",
     "Version": "1.8"
@@ -11138,7 +10903,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/recog"
     },
-    "Status": "deposited",
     "Subtitle": "A collection of group recognition methods",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
@@ -11218,14 +10982,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/RepnDecomp"
     },
-    "Status": "deposited",
     "Subtitle": "Decompose representations of finite groups into irreducibles",
     "TestFile": "tst/testall.g",
     "Version": "1.2.1"
   },
   "repsn": {
     "AbstractHTML": "The package provides <span class=\"pkgname\">GAP</span> functions for computing characteristic zero matrix representations of finite groups.",
-    "AcceptDate": "05/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/repsn/releases/download/v3.1.0/repsn-3.1.0",
     "AutoDoc": {
@@ -11234,7 +10996,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "22/02/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11291,7 +11052,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/repsn"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing representations of finite groups",
     "TestFile": "tst/testall.g",
     "Version": "3.1.0"
@@ -11372,7 +11132,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/resclasses"
     },
-    "Status": "deposited",
     "Subtitle": "Set-Theoretic Computations with Residue Classes",
     "TestFile": "tst/testall.g",
     "Version": "4.7.3"
@@ -11551,7 +11310,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Dictionaries of external rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
@@ -11643,14 +11401,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "SCO - Simplicial Cohomology of Orbifolds",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "scscp": {
     "AbstractHTML": "This package implements the <a href=\"https://www.openmath.org/standard/scscp/\">Symbolic Computation Software Composability Protocol</a> for the GAP system.",
-    "AcceptDate": "08/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/scscp/releases/download/v2.3.1/SCSCP-2.3.1",
     "Autoload": false,
@@ -11658,7 +11414,6 @@
     "BinaryFiles": [
       "demo/maple2gap.mw"
     ],
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "22/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11734,7 +11489,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/scscp"
     },
-    "Status": "accepted",
     "Subtitle": "Symbolic Computation Software Composability Protocol in GAP",
     "TestFile": "tst/offline.tst",
     "Version": "2.3.1"
@@ -12107,19 +11861,16 @@
       "Type": "git",
       "URL": "https://github.com/semigroups/Semigroups"
     },
-    "Status": "deposited",
     "Subtitle": "A package for semigroups and monoids",
     "TestFile": "tst/teststandard.g",
     "Version": "5.0.2"
   },
   "sglppow": {
     "AbstractHTML": "",
-    "AcceptDate": "08/2016",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sglppow/releases/download/v2.2/sglppow-2.2",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading SglPPow 2.2\nby Michael Vaughan-Lee and Bettina Eick \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "05/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12186,7 +11937,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sglppow"
     },
-    "Status": "accepted",
     "Subtitle": "Database of groups of prime-power order for some prime-powers",
     "TestFile": "tst/testall.g",
     "Version": "2.2"
@@ -12257,14 +12007,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sgpviz"
     },
-    "Status": "deposited",
     "Subtitle": "A package for semigroup visualization",
     "TestFile": "tst/testall.g",
     "Version": "0.999.5"
   },
   "simpcomp": {
     "AbstractHTML": "<span class=\"pkgname\">simpcomp</span> is a <span class=\"pkgname\">GAP</span> package for working with simplicial complexes. It allows the computation of many properties of simplicial complexes (such as the f-, g- and h-vectors, the face lattice, the automorphism group, (co-)homology with explicit basis computation, intersection form, etc.) and provides the user with functions to compute new complexes from old (simplex links and stars, connected sums, cartesian products, handle additions, bistellar flips, etc.). Furthermore, it comes with an extensive library of known triangulations of manifolds and provides the user with the possibility to create own complex libraries.<br /> <span class=\"pkgname\">simpcomp</span> caches computed properties of a simplicial complex, thus avoiding unnecessary computations, internally handles the vertex labeling of the complexes and insures the consistency of a simplicial complex throughout all operations.<br /> <span class=\"pkgname\">simpcomp</span> relies on the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">homology</span> for its homology computation, but also provides the user with an own (co-)homology algorithm in case the packacke <span class=\"pkgname\">homology</span> is not available. For automorphism group computation the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">GRAPE</span> is used, which in turn uses the program <tt>nauty</tt> by Brendan McKay. An internal automorphism group calculation algorithm in used as fallback if the <span class=\"pkgname\">GRAPE</span> package is not available.",
-    "AcceptDate": "11/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/simpcomp-team/simpcomp/releases/download/v2.1.14/simpcomp-2.1.14",
     "AutoDoc": {
@@ -12278,7 +12026,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading simpcomp 2.1.14\nby F. Effenberger and J. Spreer\nhttps://github.com/simpcomp-team/simpcomp\n",
-    "CommunicatedBy": "Graham Ellis (Galway)",
     "Date": "15/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12379,7 +12126,6 @@
       "Type": "git",
       "URL": "https://github.com/simpcomp-team/simpcomp"
     },
-    "Status": "accepted",
     "Subtitle": "A GAP toolbox for simplicial complexes",
     "TestFile": "tst/simpcomp.tst",
     "Version": "2.1.14"
@@ -12456,14 +12202,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/singular"
     },
-    "Status": "deposited",
     "Subtitle": "A GAP interface to Singular",
     "TestFile": "tst/testall.g",
     "Version": "2020.12.18"
   },
   "sla": {
     "AbstractHTML": "The package <span class=\"pkgname\">SLA</span> contains                  functionality for working with simple Lie algebras,",
-    "AcceptDate": "01/2016",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sla/releases/download/v1.5.3/sla-1.5.3",
     "AutoDoc": {
@@ -12474,7 +12218,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "15/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12534,18 +12277,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sla"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with simple Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.5.3"
   },
   "smallgrp": {
     "AbstractHTML": "The <span class=\"smallgrp\">SmallGrp</span> package provides the library of groups of certain \"small\" orders. The groups are sorted by their orders and they are listed up to isomorphism; that is, for each of the available orders a complete and irredundant list of isomorphism type representatives of groups is given.",
-    "AcceptDate": "02/2002",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/SmallGrp/releases/download/v1.5/SmallGrp-1.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Newman (Canberra)",
     "Date": "06/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12622,7 +12362,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/SmallGrp"
     },
-    "Status": "accepted",
     "Subtitle": "The GAP Small Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "1.5"
@@ -12702,19 +12441,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/smallsemi"
     },
-    "Status": "deposited",
     "Subtitle": "A library of small semigroups",
     "TestFile": "tst/testall.g",
     "Version": "0.6.13"
   },
   "sonata": {
     "AbstractHTML": "The <span class=\"pkgname\">SONATA</span> package provides methods for     the construction and analysis of finite nearrings.",
-    "AcceptDate": "04/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sonata/releases/download/v2.9.4/sonata-2.9.4",
     "AvailabilityTest": null,
     "BannerString": "\n  ___________________________________________________________________________\n /        ___\n||       /   \\                 /\\    Version 2.9.4\n||      ||   ||  |\\    |      /  \\               /\\       Erhard Aichinger\n \\___   ||   ||  |\\\\   |     /____\\_____________/__\\      Franz Binder\n     \\  ||   ||  | \\\\  |    /      \\     ||    /    \\     Juergen Ecker\n     ||  \\___/   |  \\\\ |   /        \\    ||   /      \\    Peter Mayr\n     ||          |   \\\\|  /          \\   ||               Christof Noebauer\n \\___/           |    \\|                 ||\n\n System    Of   Nearrings     And      Their Applications\n Info: https://gap-packages.github.io/sonata/\n\n",
-    "CommunicatedBy": "Charles R.B. Wright (Univ. of Oregon)",
     "Date": "20/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12821,14 +12557,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sonata"
     },
-    "Status": "accepted",
     "Subtitle": "System of nearrings and their applications",
     "TestFile": "tst/testall.g",
     "Version": "2.9.4"
   },
   "sophus": {
     "AbstractHTML": "",
-    "AcceptDate": "10/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sophus/releases/download/v1.27/sophus-1.27",
     "AutoDoc": {
@@ -12839,7 +12573,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Olexandr Konovalov (Zaporizhzhia)",
     "Date": "09/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12899,7 +12632,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sophus"
     },
-    "Status": "accepted",
     "Subtitle": "Computing in nilpotent Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.27"
@@ -12980,7 +12712,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/spinsym"
     },
-    "Status": "deposited",
     "Subtitle": "Brauer tables of spin-symmetric groups",
     "TestFile": "tst/testall.tst",
     "Version": "1.5.2"
@@ -13046,18 +12777,15 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/StandardFF"
     },
-    "Status": "dev",
     "Subtitle": "Standard finite fields and cyclic generators",
     "TestFile": "tst/testall.g",
     "Version": "0.9.4"
   },
   "symbcompcc": {
     "AbstractHTML": "The <span class=\"pkgname\">SymbCompCC</span> package computes with parametrised presentations for finite p-groups of fixed coclass.",
-    "AcceptDate": "11/2011",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/SymbCompCC/releases/download/v1.3.2/SymbCompCC-1.3.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Newman (Canberra, Australia)",
     "Date": "10/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13116,7 +12844,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/SymbCompCC"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with parametrised presentations for p-groups of fixed coclass",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
@@ -13199,7 +12926,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/Thelma"
     },
-    "Status": "deposited",
     "Subtitle": "THreshold ELements, Modeling and Applications",
     "TestFile": "tst/testall.g",
     "Version": "1.3"
@@ -13291,7 +13017,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/tomlib"
     },
-    "Status": "deposited",
     "Subtitle": "The GAP Library of Tables of Marks",
     "TestFile": "tst/testall.g",
     "Version": "1.2.9"
@@ -13381,14 +13106,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Special methods and knowledge propagation tools",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-02"
   },
   "toric": {
     "AbstractHTML": "<span class=\"pkgname\">toric</span> is a <span class=\"pkgname\">GAP</span>package for computing with toric varieties.",
-    "AcceptDate": "10/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/toric/releases/download/v1.9.5/Toric-1.9.5",
     "AutoDoc": {
@@ -13399,7 +13122,6 @@
     },
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "07/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13457,7 +13179,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/toric"
     },
-    "Status": "accepted",
     "Subtitle": "toric varieties and some combinatorial geometry computations",
     "TestFile": "tst/testall.g",
     "Version": "1.9.5"
@@ -13570,7 +13291,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/ToricVarieties_project"
     },
-    "Status": "deposited",
     "Subtitle": "A package to handle toric varieties",
     "TestFile": "tst/testall.g",
     "Version": "2022.07.13"
@@ -13626,19 +13346,16 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/transgrp"
     },
-    "Status": "deposited",
     "Subtitle": "Transitive Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "3.6.3"
   },
   "ugaly": {
     "AbstractHTML": "<span class=\"pkgname\">UGALY</span> (Universal Groups Acting LocallY) is a <span class=\"pkgname\">GAP</span> package that provides methods to create, analyse and find local actions of generalised universal groups acting on locally finite regular trees, following Burger-Mozes and Tornier.",
-    "AcceptDate": "07/2021",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/UGALY/releases/download/v4.0.3/UGALY-4.0.3",
     "AvailabilityTest": null,
     "BannerString": "\nVersion 4.0.3\n __  __     ______     ______     __         __  __    \n/\\ \\/\\ \\   /\\  ___\\   /\\  __ \\   /\\ \\       /\\ \\_\\ \\   \n\\ \\ \\_\\ \\  \\ \\ \\__ \\  \\ \\  __ \\  \\ \\ \\____  \\ \\____ \\  by Khalil Hannouch\n \\ \\_____\\  \\ \\_____\\  \\ \\_\\ \\_\\  \\ \\_____\\  \\/\\_____\\   and Stephan Tornier\n  \\/_____/   \\/_____/   \\/_/\\/_/   \\/_____/   \\/_____/ \n                                                       \n Universal      Groups      Acting        LocallY    \n",
-    "CommunicatedBy": "Laurent Bartholdi (G\u00f6ttingen)",
     "Date": "14/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13706,7 +13423,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/UGALY"
     },
-    "Status": "accepted",
     "Subtitle": "Universal Groups Acting LocallY",
     "TestFile": "tst/testall.g",
     "Version": "4.0.3"
@@ -13774,18 +13490,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/unipot"
     },
-    "Status": "deposited",
     "Subtitle": "Computing with elements of unipotent subgroups of Chevalley groups",
     "TestFile": "tst/testall.g",
     "Version": "1.5"
   },
   "unitlib": {
     "AbstractHTML": "The <span class=\"pkgname\">UnitLib</span> package extends the <span class=\"pkgname\">LAGUNA</span> package and provides the library of normalized unit groups of modular group algebras of all finite p-groups of order less than 243 over the field of p elements.",
-    "AcceptDate": "03/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/unitlib/releases/download/v4.1.0/unitlib-4.1.0",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "26/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13861,7 +13574,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/unitlib"
     },
-    "Status": "accepted",
     "Subtitle": "Library of normalized unit groups of modular group algebras",
     "TestFile": "tst/testall.g",
     "Version": "4.1.0"
@@ -13989,7 +13701,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/utils"
     },
-    "Status": "deposited",
     "Subtitle": "Utility functions in GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.76"
@@ -14058,7 +13769,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/uuid"
     },
-    "Status": "deposited",
     "Subtitle": "RFC 4122 UUIDs",
     "TestFile": "tst/testall.g",
     "Version": "0.7"
@@ -14139,18 +13849,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/walrus"
     },
-    "Status": "deposited",
     "Subtitle": "A new approach to proving hyperbolicity",
     "TestFile": "tst/testall.g",
     "Version": "0.9991"
   },
   "wedderga": {
     "AbstractHTML": "<span class=\"pkgname\">Wedderga</span> is the package to compute the simple components of the Wedderburn decomposition of semisimple group algebras of finite groups over finite fields and over subfields of finite cyclotomic extensions of the rationals. It also contains functions that produce the primitive central idempotents of semisimple group algebras and functions for computing Schur indices. Other functions of <span class=\"pkgname\">Wedderga</span> allow one to construct crossed products over a group with coefficients in an associative ring with identity and the multiplication determined by a given action and twisting.",
-    "AcceptDate": "01/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/wedderga/releases/download/v4.10.2/wedderga-4.10.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "29/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14298,18 +14005,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/wedderga"
     },
-    "Status": "accepted",
     "Subtitle": "Wedderburn Decomposition of Group Algebras",
     "TestFile": "tst/testall.g",
     "Version": "4.10.2"
   },
   "xgap": {
     "AbstractHTML": "The <span class=\"pkgname\">XGAP</span> package allows to use graphics in GAP.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xgap/releases/download/v4.31/xgap-4.31",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hi\u00df (Aachen)",
     "Date": "17/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14372,14 +14076,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xgap"
     },
-    "Status": "accepted",
     "Subtitle": "a graphical user interface for GAP",
     "TestFile": "tst/testall.g",
     "Version": "4.31"
   },
   "xmod": {
     "AbstractHTML": "The <span class=\"pkgname\">XMod</span> package provides a collection   of functions for computing with crossed modules and cat1-groups, their derivations and sections, morphisms of these structures, and higher-dimensional generalisations.",
-    "AcceptDate": "12/1996",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xmod/releases/download/v2.88/XMod-2.88",
     "AutoDoc": {
@@ -14392,7 +14094,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading XMod 2.88 (methods for crossed modules and cat1-groups)\nby Chris Wensley (https://github.com/cdwensley),\n with contributions from:\n    Murat Alp (muratalp@nigde.edu.tr),\n    Alper Odabas (aodabas@ogu.edu.tr),\nand Enver Uslu.\n-----------------------------------------------------------------------------\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "28/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14501,7 +14202,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmod"
     },
-    "Status": "accepted",
     "Subtitle": "Crossed Modules and Cat1-Groups",
     "SupportEmail": "c.d.wensley@bangor.ac.uk",
     "TestFile": "tst/testall.g",
@@ -14509,7 +14209,6 @@
   },
   "xmodalg": {
     "AbstractHTML": "The <span class=\"pkgname\">XModAlg</span> package provides a collection of functions for computing with crossed modules and cat1-algebras and morphisms of these structures.",
-    "AcceptDate": "",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xmodalg/releases/download/v1.22/XModAlg-1.22",
     "AutoDoc": {
@@ -14522,7 +14221,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "-----------------------------------------------------------------------------\nLoading XModAlg 1.22 (29/04/2022) for GAP 4.11 \nMethods for crossed modules of commutative algebras and cat1-algebras\nby Zekeriya Arvasi (zarvasi@ogu.edu.tr) and Alper Odabas (aodabas@ogu.edu.tr).\n-----------------------------------------------------------------------------\n",
-    "CommunicatedBy": "",
     "Date": "29/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14589,7 +14287,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmodalg"
     },
-    "Status": "deposited",
     "Subtitle": "Crossed Modules and Cat1-Algebras",
     "SupportEmail": "aodabas@ogu.edu.tr",
     "TestFile": "tst/testall.g",
@@ -14667,7 +14364,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/YangBaxter"
     },
-    "Status": "deposited",
     "Subtitle": "Combinatorial Solutions for the Yang-Baxter equation",
     "TestFile": "tst/testall.g",
     "Version": "0.10.1"
@@ -14754,7 +14450,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ZeroMQInterface"
     },
-    "Status": "deposited",
     "Subtitle": "ZeroMQ bindings for GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.14"

--- a/_data/package-infos/4-12-1.json
+++ b/_data/package-infos/4-12-1.json
@@ -63,19 +63,16 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A link to 4ti2",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-01"
   },
   "ace": {
     "AbstractHTML": "The <span class=\"pkgname\">ACE</span> package provides both an    interactive and non-interactive interface with the Todd-Coxeter coset   enumeration functions of the ACE (Advanced Coset Enumerator) C program.",
-    "AcceptDate": "04/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/ace/releases/download/v5.6.1/ace-5.6.1",
     "AvailabilityTest": null,
     "BannerString": "---------------------------------------------------------------------------\nLoading    ACE (Advanced Coset Enumerator) 5.6.1\nGAP code by Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)\n       Alexander Hulpke (https://www.math.colostate.edu/~hulpke)\n           [uses ACE binary (C code program) version: 3.001]\nC code by  George Havas (http://staff.itee.uq.edu.au/havas)\n           Colin Ramsay <cram@itee.uq.edu.au>\nCo-maintainer: Max Horn <horn@mathematik.uni-kl.de>\n\n                 For help, type: ?ACE\n---------------------------------------------------------------------------\n",
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "26/09/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -172,18 +169,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ace"
     },
-    "Status": "accepted",
     "Subtitle": "Advanced Coset Enumerator",
     "TestFile": "tst/aceds.tst",
     "Version": "5.6.1"
   },
   "aclib": {
     "AbstractHTML": "The <span class=\"pkgname\">AClib</span> package contains a library of almost crystallographic groups and a some algorithms to compute with these groups. A group is called almost crystallographic if it is finitely generated nilpotent-by-finite and has no non-trivial finite normal subgroups. Further, an almost crystallographic group is called almost Bieberbach if it is torsion-free. The almost crystallographic groups of Hirsch length 3 and a part of the almost cyrstallographic groups of Hirsch length 4 have been classified by Dekimpe. This classification includes all almost Bieberbach groups of Hirsch lengths 3 or 4. The AClib package gives access to this classification; that is, the package contains this library of groups in a computationally useful form. The groups in this library are available in two different representations. First, each of the groups of Hirsch length 3 or 4 has a rational matrix representation of dimension 4 or 5, respectively, and such representations are available in this package. Secondly, all the groups in this libraray are (infinite) polycyclic groups and the package also incorporates polycyclic presentations for them. The polycyclic presentations can be used to compute with the given groups using the methods of the Polycyclic package.",
-    "AcceptDate": "02/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/aclib/releases/download/v1.3.2/aclib-1.3.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -257,7 +251,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/aclib"
     },
-    "Status": "accepted",
     "Subtitle": "Almost Crystallographic Groups - A Library and Algorithms",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
@@ -335,7 +328,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/AGT"
     },
-    "Status": "other",
     "Subtitle": "Algebraic Graph Theory",
     "SupportEmail": "r.evans@qmul.ac.uk",
     "TestFile": "tst/testall.g",
@@ -343,11 +335,9 @@
   },
   "alnuth": {
     "AbstractHTML": "The <span class=\"pkgname\">Alnuth</span> package provides various methods to compute with number fields which are given by a defining polynomial or by generators. Some of the methods provided in this package are written in <span class=\"pkgname\">GAP</span> code. The other part of the methods is imported from the computer algebra system PARI/GP. Hence this package contains some <span class=\"pkgname\">GAP</span> functions and an interface to some functions in the computer algebra system PARI/GP. The main methods included in <span class=\"pkgname\">Alnuth</span> are: creating a number field, computing its maximal order (using PARI/GP), computing its unit group (using PARI/GP) and a presentation of this unit group, computing the elements of a given norm of the number field (using PARI/GP), determining a presentation for a finitely generated multiplicative subgroup (using PARI/GP), and factoring polynomials defined over number fields (using PARI/GP).",
-    "AcceptDate": "01/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/alnuth/releases/download/v3.2.1/alnuth-3.2.1",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "05/04/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -431,14 +421,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/alnuth"
     },
-    "Status": "accepted",
     "Subtitle": "Algebraic number theory and an interface to PARI/GP",
     "TestFile": "tst/testall.g",
     "Version": "3.2.1"
   },
   "anupq": {
     "AbstractHTML": "The <span class=\"pkgname\">ANUPQ</span> package provides an interactive    interface to the p-quotient, p-group generation and standard presentation    algorithms of the ANU pq C program.",
-    "AcceptDate": "04/2002",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/anupq/releases/download/v3.2.6/anupq-3.2.6",
     "AutoDoc": {
@@ -448,7 +436,6 @@
     },
     "AvailabilityTest": null,
     "BannerFunction": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "07/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -532,18 +519,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/anupq"
     },
-    "Status": "accepted",
     "Subtitle": "ANU p-Quotient",
     "TestFile": "tst/testinstall.g",
     "Version": "3.2.6"
   },
   "atlasrep": {
     "AbstractHTML": "The package provides a <span class=\"pkgname\">GAP</span> interface to the <a href=\"http://atlas.math.rwth-aachen.de/Atlas/v3\">Atlas of Group Representations</a>",
-    "AcceptDate": "04/2001",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/atlasrep-2.1.6",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "19/10/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -660,7 +644,6 @@
       }
     ],
     "README_URL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/README.md",
-    "Status": "accepted",
     "Subtitle": "A GAP Interface to the Atlas of Group Representations",
     "TestFile": "tst/testauto.g",
     "Version": "2.1.6"
@@ -781,19 +764,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/AutoDoc"
     },
-    "Status": "deposited",
     "Subtitle": "Generate documentation from GAP source code",
     "TestFile": "tst/testall.g",
     "Version": "2022.10.20"
   },
   "automata": {
     "AbstractHTML": "The <span class=\"pkgname\">Automata</span> package, as its name suggests, is package with algorithms to deal with automata.",
-    "AcceptDate": "09/2004",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/automata/releases/download/v1.15/automata-1.15",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
     "Date": "20/03/2022",
     "Dependencies": {
       "GAP": ">=4.8",
@@ -863,20 +843,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/automata"
     },
-    "Status": "accepted",
     "Subtitle": "A package on automata",
     "TestFile": "tst/testall.g",
     "Version": "1.15"
   },
   "automgrp": {
     "AbstractHTML": "The <span class=\"pkgname\">AutomGrp</span> package provides methods for computations with groups and semigroups generated by finite automata or given by wreath recursion, as well as with their finitely generated subgroups and elements.",
-    "AcceptDate": "03/2016",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/automgrp/releases/download/v1.3.2/automgrp-1.3.2",
     "Autoload": true,
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\n     ^                                    ___                   \n    / \\                                  /   \\                  \n   /   \\           _______  ___         ||        ___   __      \n  /_____\\   ||  ||    |    /   \\  |\\ /| ||   __ |/   | |  \\    \n /       \\  ||  ||    |   ||   || | V | ||   || |      |__/    \n/         \\  \\__/     |    \\___/  |   |  \\___/  |      |        \n                                                                \nLoading  AutomGrp 1.3.2 (Automata Groups and Semigroups)\nby Yevgen Muntyan (muntyan@fastmail.fm)\n   Dmytro Savchuk (http://savchuk.myweb.usf.edu/)\nHomepage: https://gap-packages.github.io/automgrp\n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
     "Date": "30/09/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -948,18 +925,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/automgrp"
     },
-    "Status": "accepted",
     "Subtitle": "Automata groups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
   },
   "autpgrp": {
     "AbstractHTML": "The <span class=\"pkgname\">AutPGrp</span> package introduces a new function to compute the automorphism group of a finite $p$-group. The underlying algorithm is a refinement of the methods described in O'Brien (1995). In particular, this implementation is more efficient in both time and space requirements and hence has a wider range of applications than the ANUPQ method. Our package is written in GAP code and it makes use of a number of methods from the GAP library such as the MeatAxe for matrix groups and permutation group functions. We have compared our method to the others available in GAP. Our package usually out-performs all but the method designed for finite abelian groups. We note that our method uses the small groups library in certain cases and hence our algorithm is more effective if the small groups library is installed.",
-    "AcceptDate": "09/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/autpgrp/releases/download/v1.11/autpgrp-1.11",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Derek F. Holt (Warwick)",
     "Date": "05/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1031,7 +1005,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/autpgrp"
     },
-    "Status": "accepted",
     "Subtitle": "Computing the Automorphism Group of a p-Group",
     "TestFile": "tst/testall.g",
     "Version": "1.11"
@@ -1112,7 +1085,6 @@
       }
     ],
     "README_URL": "https://www.math.rwth-aachen.de/~Browse/README",
-    "Status": "deposited",
     "Subtitle": "browsing applications and ncurses interface",
     "Version": "1.8.18"
   },
@@ -1208,14 +1180,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Categories, Algorithms, Programming",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-06"
   },
   "caratinterface": {
     "AbstractHTML": "This package provides <span class=\"pkgname\">GAP</span> interface routines to some of the stand-alone programs of <a href=\"https://lbfm-rwth.github.io/carat\">CARAT</a>, a package for the computation with crystallographic groups. CARAT is to a large extent complementary to the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">Cryst</span>. In particular, it provides routines for the computation of normalizers and conjugators of finite unimodular groups in GL(n,Z), and routines for the computation of Bravais groups, which are all missing in <span class=\"pkgname\">Cryst</span>. A catalog of Bravais groups up to dimension 6 is also provided.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CaratInterface/CaratInterface-2.3.4",
     "AvailabilityTest": null,
@@ -1224,7 +1194,6 @@
       "doc/manual.dvi",
       "carat.tgz"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1278,7 +1247,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/caratinterface"
     },
-    "Status": "accepted",
     "Subtitle": "Interface to CARAT, a crystallographic groups package",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -1343,18 +1311,15 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CddInterface"
     },
-    "Status": "deposited",
     "Subtitle": "Gap interface to Cdd package",
     "TestFile": "tst/testall.g",
     "Version": "2022.08.11"
   },
   "circle": {
     "AbstractHTML": "The <span class=\"pkgname\">Circle</span> package provides functionality for computations in adjoint groups of finite associative rings. It allows to construct circle objects that will respect the circle multiplication r*s=r+s+rs, create multiplicative groups, generated by such objects, and compute groups of elements, invertible with respect to this operation. Also it may serve as an example of extending the GAP system with new multiplicative objects.",
-    "AcceptDate": "01/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/circle/releases/download/v1.6.5/circle-1.6.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "27/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1421,7 +1386,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/circle"
     },
-    "Status": "accepted",
     "Subtitle": "Adjoint groups of finite rings",
     "TestFile": "tst/testall.g",
     "Version": "1.6.5"
@@ -1515,19 +1479,16 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/magmapresentations/"
     },
-    "Status": "deposited",
     "Subtitle": "Classical Group Presentations",
     "TestFile": "tst/testall.g",
     "Version": "1.22"
   },
   "cohomolo": {
     "AbstractHTML": "The <span class=\"pkgname\">cohomolo</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for computing Schur multipliers and covering groups of finite groups   and first and second cohomology groups of finite groups acting   on finite modules",
-    "AcceptDate": "01/1970",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/cohomolo/releases/download/v1.6.10/cohomolo-1.6.10",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "unknown (unknown)",
     "Date": "30/03/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -1585,18 +1546,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cohomolo"
     },
-    "Status": "accepted",
     "Subtitle": "Cohomology groups of finite groups on finite modules",
     "TestFile": "tst/testall.g",
     "Version": "1.6.10"
   },
   "congruence": {
     "AbstractHTML": "The <span class=\"pkgname\">Congruence </span> package provides functions to construct several types of canonical congruence subgroups in SL_2(Z), and also intersections of a finite number of such subgroups. Furthermore, it implements the algorithm for generating Farey symbols for congruence subgroups and using them to produce a system of independent generators for these subgroups",
-    "AcceptDate": "09/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/congruence/releases/download/v1.2.4/congruence-1.2.4",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Graham Ellis (Galway)",
     "Date": "27/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1683,14 +1641,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/congruence"
     },
-    "Status": "accepted",
     "Subtitle": "Congruence subgroups of SL(2,Integers)",
     "TestFile": "tst/testall.g",
     "Version": "1.2.4"
   },
   "corelg": {
     "AbstractHTML": "The package <span class=\"pkgname\">CoReLG</span> contains functionality for working with real semisimple Lie algebras.",
-    "AcceptDate": "01/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/corelg/releases/download/v1.56/corelg-1.56",
     "AutoDoc": {
@@ -1702,7 +1658,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "24/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1776,14 +1731,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/corelg"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with real Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.56"
   },
   "crime": {
     "AbstractHTML": "This package computes the cohomology rings of finite p-groups, induced maps, and Massey products.",
-    "AcceptDate": "10/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/crime/releases/download/v1.6/crime-1.6",
     "AutoDoc": {
@@ -1795,7 +1748,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\nThis is CRIME, Version 1.6\n\"Obviously crime pays, or there'd be no crime\".\n                                G. Gordon Liddy\n\n",
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "17/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1847,14 +1799,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crime"
     },
-    "Status": "accepted",
     "Subtitle": "A GAP Package to Calculate Group Cohomology and Massey Products",
     "TestFile": "tst/testall.g",
     "Version": "1.6"
   },
   "crisp": {
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">CRISP</span> provides algorithms for computing subgroups of finite soluble groups related to a group class <i>C</i>. In particular, it allows to compute <i>C</i>-radicals and <i>C</i>-injectors for Fitting classes (and Fitting sets) <i>C</i>, <i>C</i>-residuals for formations <i>C</i>, and <i>C</i>-projectors for Schunck classes <i>C</i>. In order to carry out these computations, the group class <i>C</i> must be represented by an algorithm which can decide membership in the group class.</p>  <p>Moreover, <span class=\"pkgname\">CRISP</span> contains algorithms for the computation of normal subgroups invariant under a prescribed set of automorphisms and belonging to a given group class.</p>  <p>This includes an improved method to compute the set of all normal subgroups of a finite soluble group, its characteristic subgroups, minimal normal subgroups and the socle and <i>p</i>-socles for given primes <i>p</i>.",
-    "AcceptDate": "12/2000",
     "ArchiveFormats": ".tar.bz2",
     "ArchiveURL": "http://www.icm.tu-bs.de/~bhoeflin/crisp/crisp-1.4.5",
     "Autoload": true,
@@ -1863,7 +1813,6 @@
     "BinaryFiles": [
       "doc/manual.pdf"
     ],
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "07/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -1919,7 +1868,6 @@
       "Type": "git",
       "URL": "https://github.com/bh11/crisp.git"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with Radicals, Injectors, Schunck classes and Projectors",
     "TestFile": "tst/testall.g",
     "Version": "1.4.5"
@@ -1983,14 +1931,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crypting"
     },
-    "Status": "deposited",
     "Subtitle": "Hashes and Crypto in GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.10.3"
   },
   "cryst": {
     "AbstractHTML": "This package, previously known as <span class=\"pkgname\">CrystGAP</span>, provides a rich set of methods for the computation with affine crystallographic groups, in particular space groups. Affine crystallographic groups are fully supported both in representations acting from the right or from the left, the latter one being preferred by crystallographers. Functions to determine representatives of all space group types of a given dimension are also provided. Where necessary, <span class=\"pkgname\">Cryst</span> can also make use of functionality provided by the package <span class=\"pkgname\">CaratInterface</span>.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/Cryst/cryst-4.1.25",
     "AvailabilityTest": null,
@@ -1998,7 +1944,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2092,7 +2037,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cryst"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with crystallographic groups",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -2100,7 +2044,6 @@
   },
   "crystcat": {
     "AbstractHTML": "This package provides a catalog of crystallographic groups of dimensions 2, 3, and 4 which covers most of the data contained in the book <em>Crystallographic groups of four-dimensional space</em> by H. Brown, R. B&uuml;low, J. Neub&uuml;ser, H. Wondratschek, and H. Zassenhaus (John Wiley, New York, 1978). Methods for the computation with these groups are provided by the package <span class=\"pkgname\">Cryst</span>, which must be installed as well.",
-    "AcceptDate": "02/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CrystCat/crystcat-1.1.10",
     "AvailabilityTest": null,
@@ -2108,7 +2051,6 @@
       "doc/manual.pdf",
       "doc/manual.dvi"
     ],
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2171,7 +2113,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/crystcat"
     },
-    "Status": "accepted",
     "Subtitle": "The crystallographic groups catalog",
     "SupportEmail": "gaehler@math.uni-bielefeld.de",
     "TestFile": "tst/testall.g",
@@ -2284,19 +2225,16 @@
       }
     ],
     "README_URL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/ctbllib/README.md",
-    "Status": "deposited",
     "Subtitle": "The GAP Character Table Library",
     "TestFile": "tst/testauto.g",
     "Version": "1.3.4"
   },
   "cubefree": {
     "AbstractHTML": "The <span class=\"pkgname\">Cubefree</span> package contains methods to construct up to isomorphism the groups of a given (reasonable) cubefree order. The main function ConstructAllCFGroups(n) constructs all groups of a given cubefree order n. The function NumberCFGroups(n) counts all groups of a cubefree order n. Furthermore, IrreducibleSubgroupsOfGL(2,q) constructs the irreducible subgroups of GL(2,q), q=p^r, p>=5 prime, up to conjugacy and RewriteAbsolutelyIrreducibleMatrixGroup(G) rewrites the absolutely irreducible matrix group G (over a finite field) over a minimal subfield.",
-    "AcceptDate": "10/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/cubefree/releases/download/v1.19/cubefree-1.19",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "21/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2356,7 +2294,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cubefree"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing the Groups of a Given Cubefree Order",
     "TestFile": "tst/testall.g",
     "Version": "1.19"
@@ -2437,7 +2374,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/curlInterface"
     },
-    "Status": "deposited",
     "Subtitle": "Simple Web Access",
     "TestFile": "tst/testall.g",
     "Version": "2.3.1"
@@ -2518,7 +2454,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/cvec"
     },
-    "Status": "deposited",
     "Subtitle": "Compact vectors over finite fields",
     "TestFile": "tst/testall.g",
     "Version": "2.7.6"
@@ -2619,7 +2554,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/datastructures"
     },
-    "Status": "deposited",
     "Subtitle": "Collection of standard data structures for GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.2.7"
@@ -2693,14 +2627,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/DeepThought"
     },
-    "Status": "deposited",
     "Subtitle": "This package provides functions for computations in finitely generated nilpotent groups based on the Deep Thought algorithm.",
     "TestFile": "tst/testall.g",
     "Version": "1.0.6"
   },
   "design": {
     "AbstractHTML": "<span class=\"pkgname\">DESIGN</span> is a package for constructing, classifying, partitioning, and studying block designs.",
-    "AcceptDate": "08/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/design/releases/download/v1.7/design-1.7",
     "AvailabilityTest": null,
@@ -2708,7 +2640,6 @@
       "doc/manual.dvi",
       "doc/manual.pdf"
     ],
-    "CommunicatedBy": "Akos Seress (Ohio State)",
     "Date": "18/03/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -2771,14 +2702,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/design"
     },
-    "Status": "accepted",
     "Subtitle": "The Design Package for GAP",
     "TestFile": "tst/testall.g",
     "Version": "1.7"
   },
   "difsets": {
     "AbstractHTML": "The <span class=\"pkgname\">DifSets</span> package is a         <span class=\"pkgname\">GAP</span> package implementing an algorithm         for enumerating all difference sets up to equivalence in a group.",
-    "AcceptDate": "07/2019",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/dylanpeifer/difsets/releases/download/v2.3.1/difsets-2.3.1",
     "AutoDoc": {
@@ -2788,7 +2717,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alexander Hulpke (Colorado State)",
     "Date": "14/09/2019",
     "Dependencies": {
       "GAP": "4.9",
@@ -2846,7 +2774,6 @@
       "Type": "git",
       "URL": "https://github.com/dylanpeifer/difsets"
     },
-    "Status": "accepted",
     "Subtitle": "an algorithm for enumerating all difference sets in a group",
     "SupportEmail": "djp282@cornell.edu",
     "TestFile": "tst/testall.g",
@@ -3210,19 +3137,16 @@
       "Type": "git",
       "URL": "https://github.com/digraphs/Digraphs"
     },
-    "Status": "deposited",
     "Subtitle": "Graphs, digraphs, and multidigraphs in GAP",
     "TestFile": "tst/teststandard.g",
     "Version": "1.6.0"
   },
   "edim": {
     "AbstractHTML": "This package provides  a collection of functions for computing the Smith normal form of integer matrices and some related utilities.",
-    "AcceptDate": "08/1999",
     "ArchiveFormats": ".tar.bz2  .tar.gz   -win.zip",
     "ArchiveURL": "https://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/EDIM-1.3.6",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Atkinson (St Andrews)",
     "Date": "23/09/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -3278,7 +3202,6 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/EDIM"
     },
-    "Status": "accepted",
     "Subtitle": "Elementary Divisors of Integer Matrices",
     "TestFile": "tst/edim.tst",
     "Version": "1.3.6"
@@ -3364,7 +3287,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/example"
     },
-    "Status": "deposited",
     "Subtitle": "Example/Template of a GAP Package",
     "SupportEmail": "obk1@st-andrews.ac.uk",
     "TestFile": "tst/testall.g",
@@ -3478,14 +3400,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Examples for the GAP Package homalg",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-01"
   },
   "factint": {
     "AbstractHTML": "\nThis package provides routines for factoring integers, in particular:\n<ul>\n  <li>Pollard's <em>p</em>-1</li>\n  <li>Williams' <em>p</em>+1</li>\n  <li>Elliptic Curves Method (ECM)</li>\n  <li>Continued Fraction Algorithm (CFRAC)</li>\n  <li>Multiple Polynomial Quadratic Sieve (MPQS)</li>\n</ul>\nIt also provides access to Richard P. Brent's tables of factors of integers of the form <em>b</em>^<em>k</em> +/- 1.\n",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/FactInt/releases/download/v1.6.3/FactInt-1.6.3",
     "AutoDoc": {
@@ -3496,7 +3416,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Atkinson (St. Andrews)",
     "Date": "15/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3567,7 +3486,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FactInt"
     },
-    "Status": "accepted",
     "Subtitle": "Advanced Methods for Factoring Integers",
     "TestFile": "tst/testall.g",
     "Version": "1.6.3"
@@ -3634,19 +3552,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ferret"
     },
-    "Status": "deposited",
     "Subtitle": "Backtrack Search in Permutation Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.0.9"
   },
   "fga": {
     "AbstractHTML": "The <span class=\"pkgname\">FGA</span> package installs methods for    computations with finitely generated subgroups of free groups and    provides a presentation for their automorphism groups.",
-    "AcceptDate": "05/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "http://www.icm.tu-bs.de/ag_algebra/software/FGA/FGA-1.4.0",
     "Autoload": true,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St. Andrews)",
     "Date": "23/03/2018",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3693,14 +3608,12 @@
       "Type": "git",
       "URL": "https://github.com/chsievers/fga"
     },
-    "Status": "accepted",
     "Subtitle": "Free Group Algorithms",
     "TestFile": "tst/testall.g",
     "Version": "1.4.0"
   },
   "fining": {
     "AbstractHTML": "<span class=\"pkgname\">FinInG</span> is a package for computation in Finite Incidence Geometry. It provides users with the basic tools to work in  various areas of finite geometry from the realms of projective spaces to the flat  lands of generalised polygons. The algebraic power of GAP is employed, particularly  in its facility with matrix and permutation groups.",
-    "AcceptDate": "11/2017",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/FinInG/releases/download/v1.5.1/fining-1.5.1",
     "AutoDoc": {
@@ -3714,7 +3627,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "-------------------------------------------------------------------------------\n         ______________       ________      _________   __________ __          \n         ___  ____/__(_)__________  _/________  ____/   __<  /_  // /          \n         __  /_   __  /__  __ __  / __  __   / __     __  /_  // /_          \n         _  __/   _  / _  / / /_/ /  _  / / / /_/ /     _  /_/__  __/          \n         /_/      /_/  /_/ /_//___/  /_/ /_/____/      /_/_(_)/_/             \n-------------------------------------------------------------------------------\nLoading  FinInG 1.5.1 (Finite Incidence Geometry) \nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Anton Betten (http://www.math.colostate.edu/~betten)\n   Philippe Cara (http://homepages.vub.ac.be/~pcara)\n   Jan De Beule (http://www.debeule.eu)\n   Michel Lavrauw (http://people.sabanciuniv.edu/~mlavrauw/)\n   Max Neunhoeffer (http://www-groups.mcs.st-and.ac.uk/~neunhoef/)\nFor help, type: ?FinInG \n---------------------------------------------------------------------\n",
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
     "Date": "21/09/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3854,7 +3766,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FinInG"
     },
-    "Status": "accepted",
     "Subtitle": "Finite Incidence Geometry",
     "TestFile": "tst/testall.g",
     "Version": "1.5.1"
@@ -3919,18 +3830,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/float"
     },
-    "Status": "deposited",
     "Subtitle": "Integration of mpfr, mpfi, mpc, fplll and cxsc in GAP",
     "TestFile": "tst/testall.g",
     "Version": "1.0.3"
   },
   "format": {
     "AbstractHTML": "This package provides functions for computing with formations of finite solvable groups.",
-    "AcceptDate": "12/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/format/releases/download/v1.4.3/format-1.4.3",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -3998,14 +3906,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/format"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with formations of finite solvable groups.",
     "TestFile": "tst/testall.g",
     "Version": "1.4.3"
   },
   "forms": {
     "AbstractHTML": "This package can be used for work with sesquilinear and quadratic forms on finite vector spaces; objects that are used to describe polar spaces and classical groups.",
-    "AcceptDate": "03/2009",
     "ArchiveFormats": ".tar.gz .zip .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/forms/releases/download/v1.2.9/forms-1.2.9",
     "AutoDoc": {
@@ -4015,7 +3921,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "---------------------------------------------------------------------\nLoading 'Forms' 1.2.9 (14/10/2022)\nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Jan De Beule (http://www.debeule.eu)\nFor help, type: ?Forms \n---------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (London)",
     "Date": "14/10/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4086,18 +3991,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/forms"
     },
-    "Status": "accepted",
     "Subtitle": "Sesquilinear and Quadratic",
     "TestFile": "tst/testall.g",
     "Version": "1.2.9"
   },
   "fplsa": {
     "AbstractHTML": "The <span class=\"pkgname\">FPLSA</span> package uses    the authors' C program (version 4.0) that implements    a Lie Todd-Coxeter method for converting    finitely presented Lie algebras into isomorphic    structure constant algebras.    This is called via the GAP function IsomorphismSCTableAlgebra.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/FPLSA/releases/download/v1.2.5/FPLSA-1.2.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Steve Linton (St Andrews)",
     "Date": "10/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4159,7 +4061,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/FPLSA"
     },
-    "Status": "accepted",
     "Subtitle": "Finitely Presented Lie Algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.2.5"
@@ -4178,7 +4079,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "Loading FR 2.4.10 ...\n",
-    "CommunicatedBy": "G\u00f6tz Pfeiffer (NUI Galway)",
     "Date": "10/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4257,7 +4157,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/fr"
     },
-    "Status": "deposited",
     "Subtitle": "Computations with functionally recursive groups",
     "TestFile": "tst/testall.g",
     "Version": "2.4.10"
@@ -4331,7 +4230,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/Francy"
     },
-    "Status": "deposited",
     "Subtitle": "Framework for Interactive Discrete Mathematics",
     "TestFile": "tst/testall.g",
     "Version": "1.2.5"
@@ -4426,18 +4324,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/fwtree"
     },
-    "Status": "deposited",
     "Subtitle": "Computing trees related to some pro-p-groups of finite width",
     "TestFile": "tst/testall.g",
     "Version": "1.3"
   },
   "gapdoc": {
     "AbstractHTML": "This package contains a definition of a structure for <span class='pkgname'>GAP</span> (package) documentation, based on XML. It also contains  conversion programs for producing text-, PDF- or HTML-versions of such documents, with hyperlinks if possible.",
-    "AcceptDate": "10/2006",
     "ArchiveFormats": ".tar.bz2 .tar.gz -win.zip",
     "ArchiveURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.6",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Steve Linton (St Andrews)",
     "Date": "01/07/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -4518,7 +4413,6 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/GAPDoc"
     },
-    "Status": "accepted",
     "Subtitle": "A Meta Package for GAP Documentation",
     "TestFile": "tst/test.tst",
     "Version": "1.6.6"
@@ -4610,7 +4504,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Extended Gauss functionality for GAP",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-01"
@@ -4699,14 +4592,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Gauss functionality for the homalg project",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-03"
   },
   "gbnp": {
     "AbstractHTML": "The <span class=\"pkgname\">GBNP</span> package provides algorithms for    computing Grobner bases of noncommutative polynomials with coefficients    from a field implemented in <span class=\"pkgname\">GAP</span> and with    respect to the \"total degree first then lexicographical\" ordering.    Further provided are some variations, such as a weighted and truncated    version and a tracing facility. The word \"algorithm\" is to be    interpreted loosely here: in general one cannot expect such an algorithm    to terminate, as it would imply solvability of the word problem for    finitely presented (semi)groups.",
-    "AcceptDate": "05/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/gbnp/releases/download/v1.0.5/gbnp-1.0.5",
     "AutoDoc": {
@@ -4721,7 +4612,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alexander Hulpke (Fort Collins, CO)",
     "Date": "09/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -4789,7 +4679,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/gbnp"
     },
-    "Status": "accepted",
     "Subtitle": "computing Gr\u00f6bner bases of noncommutative polynomials",
     "TestFile": "tst/testall.g",
     "Version": "1.0.5"
@@ -4866,7 +4755,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Implementations of generalized morphisms for the CAP project",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-01"
@@ -4963,7 +4851,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/genss"
     },
-    "Status": "deposited",
     "Subtitle": "Generic Schreier-Sims",
     "TestFile": "tst/testall.g",
     "Version": "1.6.8"
@@ -5116,7 +5003,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-02"
@@ -5262,14 +5148,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Endow Commutative Rings with an Abelian Grading",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-01"
   },
   "grape": {
     "AbstractHTML": "<span class=\"pkgname\">GRAPE</span> is a package for computing with graphs and groups, and is primarily designed for constructing and analysing graphs related to groups, finite geometries, and designs.",
-    "AcceptDate": "07/1993",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/grape/releases/download/v4.8.5/grape-4.8.5",
     "AvailabilityTest": null,
@@ -5279,7 +5163,6 @@
       "nauty22/nug.pdf",
       "bin/i686-pc-cygwin-gcc-default32/dreadnautB.exe"
     ],
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "26/03/2021",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5328,14 +5211,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/grape"
     },
-    "Status": "accepted",
     "Subtitle": "GRaph Algorithms using PErmutation groups",
     "TestFile": "tst/testall.g",
     "Version": "4.8.5"
   },
   "groupoids": {
     "AbstractHTML": "The groupoids package provides a collection of functions for computing with finite groupoids, graph of groups, and graphs of groupoids. These are based on the more basic structures of magmas with objects and their mappings. It provides functions for normal forms of elements in Free Products with Amalgamation and in HNN extensions. Up until April 2017 this package was named Gpd.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/groupoids/releases/download/v1.71/groupoids-1.71",
     "AutoDoc": {
@@ -5348,7 +5229,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading groupoids 1.71 (algorithms for finite groupoids)\nby Emma Moore and Chris Wensley (https://github.com/cdwensley)\n--------------------------------------------------------------\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "07/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5429,7 +5309,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/groupoids"
     },
-    "Status": "accepted",
     "Subtitle": "Calculations with finite groupoids and their homomorphisms",
     "SupportEmail": "c.d.wensley@bangor.ac.uk",
     "TestFile": "tst/testall.g",
@@ -5437,11 +5316,9 @@
   },
   "grpconst": {
     "AbstractHTML": "The <span class=\"pkgname\">GrpConst</span> package contains methods to construct up to isomorphism the groups of a given order. The FrattiniExtensionMethod constructs all soluble groups of a given order. On request it gives only those that are (or are not) nilpotent or supersolvable or that do (or do not) have normal Sylow subgroups for some given set of primes. The CyclicSplitExtensionMethod constructs all groups having a normal Sylow subgroup for orders of the type p^n *q. The method relies on the availability of a list of all groups of order p^n. The UpwardsExtensions algorithm takes as input a permutation group G and a positive integer s and returns a list of permutation groups, one for each extension of G by a soluble group of order a divisor of s. This method can used to construct the non-solvable groups of a given order by taking the perfect groups of certain orders as input for G. The programs in this package have been used to construct a large part of the Small Groups library.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/grpconst/releases/download/v2.6.2/grpconst-2.6.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "28/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5520,7 +5397,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/grpconst"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing the Groups of a Given Order",
     "TestFile": "tst/testall.g",
     "Version": "2.6.2"
@@ -5621,19 +5497,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/guarana"
     },
-    "Status": "deposited",
     "Subtitle": "Applications of Lie methods for computations with infinite polycyclic groups",
     "TestFile": "tst/testall.g",
     "Version": "0.96.3"
   },
   "guava": {
     "AbstractHTML": "<span class=\"pkgname\">GUAVA</span> is a <span class=\"pkgname\">GAP</span> package for computing with codes. <span class=\"pkgname\">GUAVA</span> can construct unrestricted (non-linear), linear and cyclic codes; transform one code into another (for example by puncturing); construct a new code from two other codes (using direct sums for example); perform decoding/error-correction; and can calculate important data of codes (such as the minumim distance or covering radius) quickly. Limited ability to compute algebraic geometric codes.",
-    "AcceptDate": "02/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/guava/releases/download/v3.17/guava-3.17",
     "AvailabilityTest": null,
     "BannerString": "\n   ____                             |\n  /                \\          /   --+--  Version 3.17\n /       |     | |\\ \\        / /|   |\n|    __  |     | | \\ \\      / / |          the GUAVA Group\n|      | |     | |--\\ \\    / /--|\n \\     | |     | |   \\ \\  / /   |\n  \\___/   \\___/  |    \\ \\/ /    |\n\n Homepage: https://gap-packages.github.io/guava\n Report issues at https://github.com/gap-packages/guava/issues\n",
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "05/09/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -5783,19 +5656,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/guava"
     },
-    "Status": "accepted",
     "Subtitle": "a GAP package for computing with error-correcting codes",
     "TestFile": "tst/guava.tst",
     "Version": "3.17"
   },
   "hap": {
     "AbstractHTML": "This package provides some functions for group cohomology and algebraic topology. ",
-    "AcceptDate": "03/2006",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/hap/releases/download/v1.47/hap-1.47",
     "AvailabilityTest": null,
     "BannerString": "Loading HAP 1.47 ...\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "14/08/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -5936,7 +5806,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hap"
     },
-    "Status": "accepted",
     "Subtitle": "Homological Algebra Programming",
     "TestFile": "tst/testquick.g",
     "Version": "1.47"
@@ -6052,7 +5921,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hapcryst"
     },
-    "Status": "deposited",
     "Subtitle": "A HAP extension for crystallographic groups",
     "TestFile": "tst/testall.g",
     "Version": "0.1.15"
@@ -6124,7 +5992,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/hecke"
     },
-    "Status": "deposited",
     "Subtitle": "Calculating decomposition matrices of Hecke algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.5.3"
@@ -6228,7 +6095,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/HeLP"
     },
-    "Status": "deposited",
     "Subtitle": "Hertweck-Luthar-Passi method.",
     "TestFile": "tst/testall.g",
     "Version": "3.5"
@@ -6326,7 +6192,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homological algebra meta-package for computable Abelian categories",
     "TestFile": "tst/testall.g",
     "Version": "2022.08-04"
@@ -6473,14 +6338,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A window to the outer world",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-01"
   },
   "idrel": {
     "AbstractHTML": "IdRel is a package for computing the identities among relations of a group presentation using rewriting, logged rewriting, monoid polynomials, module polynomials and Y-sequences.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/idrel/releases/download/v2.44/idrel-2.44",
     "AutoDoc": {
@@ -6493,7 +6356,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading IdRel 2.44 (Identities among Relations)\nby Anne Heyworth and Chris Wensley (https://github.com/cdwensley)\n-----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "04/06/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -6559,7 +6421,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/idrel"
     },
-    "Status": "accepted",
     "Subtitle": "Identities among relations",
     "TestFile": "tst/testall.g",
     "Version": "2.44"
@@ -6656,7 +6517,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/images"
     },
-    "Status": "deposited",
     "Subtitle": "Minimal and Canonical images",
     "TestFile": "tst/testall.g",
     "Version": "1.3.1"
@@ -6727,7 +6587,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/intpic"
     },
-    "Status": "deposited",
     "Subtitle": "A package for drawing integers",
     "TestFile": "tst/testall.g",
     "Version": "0.3.0"
@@ -6808,7 +6667,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/io"
     },
-    "Status": "deposited",
     "Subtitle": "Bindings for low level C library I/O routines",
     "TestFile": "tst/testall.g",
     "Version": "4.8.0"
@@ -6928,20 +6786,17 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "IO capabilities for the homalg project",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-01"
   },
   "irredsol": {
     "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">IRREDSOL</span> provides a library of all irreducible soluble subgroups of <i>GL(n,q)</i>, up to conjugacy, for <i>q<sup>n</sup></i> up to 2^24-1, and a library of the primitive soluble groups of degree up to 2^24-1.",
-    "AcceptDate": "08/2006",
     "ArchiveFormats": ".tar.bz2",
     "ArchiveURL": "https://github.com/bh11/irredsol/releases/latest/download/irredsol-1.4.3",
     "Autoload": true,
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------------\n                          IRREDSOL Version 1.4.3\n  A library of irreducible soluble linear groups over finite fields\n                and of finite primivite soluble groups\n                         by Burkhard H\u00f6fling\n----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "01/07/2021",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7003,7 +6858,6 @@
       "Type": "git",
       "URL": "https://github.com/bh11/irredsol.git"
     },
-    "Status": "accepted",
     "Subtitle": "A library of irreducible soluble linear groups over finite fields and of finite primivite soluble groups",
     "TestFile": "tst/testall.g",
     "TextBinaryFilesPatterns": [
@@ -7014,13 +6868,11 @@
   },
   "itc": {
     "AbstractHTML": "This <span class=\"pkgname\">GAP</span> package provides    access to interactive Todd-Coxeter computations    with finitely presented groups.",
-    "AcceptDate": "03/2000",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/itc/releases/download/v1.5.1/itc-1.5.1",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "\n          Loading  ITC 1.5.1  (Interactive Todd-Coxeter)\n            by V. Felsch, L. Hippe, and J. Neubueser\n              (Volkmar.Felsch@math.rwth-aachen.de)\n\n",
-    "CommunicatedBy": "Edmund F. Robertson (St Andrews)",
     "Date": "01/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7097,7 +6949,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/itc"
     },
-    "Status": "accepted",
     "Subtitle": "Interactive Todd-Coxeter",
     "Version": "1.5.1"
   },
@@ -7154,7 +7005,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/json"
     },
-    "Status": "deposited",
     "Subtitle": "Reading and Writing JSON",
     "TestFile": "tst/testall.g",
     "Version": "2.1.1"
@@ -7306,7 +7156,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/JupyterKernel"
     },
-    "Status": "deposited",
     "Subtitle": "Jupyter kernel written in GAP",
     "TestFile": "tst/testinstall.g",
     "Version": "1.4.1"
@@ -7376,7 +7225,6 @@
       "Type": "git",
       "URL": "https://github.com/nathancarter/jupyterviz"
     },
-    "Status": "deposited",
     "Subtitle": "Visualization Tools for Jupyter and the GAP REPL",
     "SupportEmail": "ncarter@bentley.edu",
     "TestFile": "tst/testall.g",
@@ -7384,7 +7232,6 @@
   },
   "kan": {
     "AbstractHTML": "The Kan package provides functions for the computation of normal forms   of representatives of double cosets of finitely presented groups.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/kan/releases/download/v1.34/kan-1.34",
     "AutoDoc": {
@@ -7397,7 +7244,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading Kan 1.34 (computing with Kan extensions)\nby Anne Heyworth and Chris Wensley (https://github.com/cdwensley)\n-----------------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "13/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7466,14 +7312,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/kan"
     },
-    "Status": "accepted",
     "Subtitle": "including double coset rewriting systems",
     "TestFile": "tst/testall.g",
     "Version": "1.34"
   },
   "kbmag": {
     "AbstractHTML": "The <span class=\"pkgname\">kbmag</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for running the Knuth-Bendix completion program on finite semigroup,   monoid or group presentations, and for attempting to compute automatic   structures of finitely presented groups",
-    "AcceptDate": "07/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/kbmag/releases/download/v1.5.10/kbmag-1.5.10",
     "AutoDoc": {
@@ -7485,7 +7329,6 @@
     },
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Oregon)",
     "Date": "23/09/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -7541,18 +7384,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/kbmag"
     },
-    "Status": "accepted",
     "Subtitle": "Knuth-Bendix on Monoids and Automatic Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.5.10"
   },
   "laguna": {
     "AbstractHTML": "The <span class=\"pkgname\">LAGUNA</span> package replaces the <span class=\"pkgname\">LAG</span> package and provides functionality for calculation of the normalized unit group of the modular group algebra of the finite p-group and for investigation of Lie algebra associated with group algebras and other associative algebras.",
-    "AcceptDate": "06/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/laguna/releases/download/v3.9.5/laguna-3.9.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Herbert Pahlings (Aachen)",
     "Date": "27/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7639,14 +7479,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/laguna"
     },
-    "Status": "accepted",
     "Subtitle": "Lie AlGebras and UNits of group Algebras",
     "TestFile": "tst/testall.g",
     "Version": "3.9.5"
   },
   "liealgdb": {
     "AbstractHTML": "",
-    "AcceptDate": "09/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liealgdb/releases/download/v2.2.1/liealgdb-2.2.1",
     "AutoDoc": {
@@ -7657,7 +7495,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "07/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7733,19 +7570,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liealgdb"
     },
-    "Status": "accepted",
     "Subtitle": "A database of Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "2.2.1"
   },
   "liepring": {
     "AbstractHTML": "",
-    "AcceptDate": "09/2014",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liepring/releases/download/v2.7/liepring-2.7",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading  LiePRing 2.7\nby Bettina Eick and Michael Vaughan-Lee \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (London)",
     "Date": "05/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7810,14 +7644,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liepring"
     },
-    "Status": "accepted",
     "Subtitle": "Database and algorithms for Lie p-rings",
     "TestFile": "tst/testall.g",
     "Version": "2.7"
   },
   "liering": {
     "AbstractHTML": "The package <span class=\"pkgname\">LieRing</span> contains                  functionality for working with finitely presented Lie rings and the Lazard correspondence.",
-    "AcceptDate": "12/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/liering/releases/download/v2.4.2/liering-2.4.2",
     "AutoDoc": {
@@ -7829,7 +7661,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "LieRing\n a package for working with Lie rings \n by Serena Cical\u00f2 and Willem de Graaf\n",
-    "CommunicatedBy": "Max Neunhoeffer (Cologne)",
     "Date": "10/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -7894,7 +7725,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/liering"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with finitely presented Lie rings",
     "TestFile": "tst/testall.g",
     "Version": "2.4.2"
@@ -7983,7 +7813,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Category of Matrices over a Field for CAP",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-03"
@@ -8087,14 +7916,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A Package for Localization of Polynomial Rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-01"
   },
   "loops": {
     "AbstractHTML": "The LOOPS package provides researchers in nonassociative algebra with a computational tool that integrates standard notions of loop theory with libraries of loops and group-theoretical algorithms of GAP. The package also expands GAP toward nonassociative structures.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/loops/releases/download/v3.4.2/loops-3.4.2",
     "AutoDoc": {
@@ -8106,7 +7933,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "31/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8177,20 +8003,17 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/loops"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with quasigroups and loops in GAP",
     "TestFile": "tst/testall.g",
     "Version": "3.4.2"
   },
   "lpres": {
     "AbstractHTML": "The LPRES Package defines new GAP objects to work with L-presented groups, namely groups given by a finite generating set and a possibly-infinite set of relations given as iterates of finitely many seed relations by a finite set of endomorphisms. The package implements nilpotent quotient, Todd-Coxeter and Reidemeister-Schreier algorithms for L-presented groups.",
-    "AcceptDate": "09/2018",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/lpres/releases/download/v1.0.3/lpres-1.0.3",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading lpres 1.0.3 ...\n",
-    "CommunicatedBy": "Alexander Konovalov (St Andrews)",
     "Date": "20/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8280,7 +8103,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/lpres"
     },
-    "Status": "accepted",
     "Subtitle": "Nilpotent Quotients of L-Presented Groups",
     "TestFile": "tst/testall.g",
     "Version": "1.0.3"
@@ -8379,18 +8201,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/MajoranaAlgebras"
     },
-    "Status": "deposited",
     "Subtitle": "A package for constructing Majorana algebras and representations",
     "TestFile": "tst/testall.g",
     "Version": "1.5"
   },
   "mapclass": {
     "AbstractHTML": "The <span class=\"pkgname\">MapClass</span> package calculates the    mapping class group orbits for a given finite group.",
-    "AcceptDate": "11/2011",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/MapClass/releases/download/v1.4.6/MapClass-1.4.6",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "17/09/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8457,7 +8276,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/MapClass"
     },
-    "Status": "accepted",
     "Subtitle": "A Package For Mapping Class Orbit Computation",
     "TestFile": "tst/testall.g",
     "Version": "1.4.6"
@@ -8539,7 +8357,6 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/matgrp/"
     },
-    "Status": "deposited",
     "Subtitle": "Matric Group Interface Routines",
     "TestFile": "tst/testall.g",
     "Version": "0.70"
@@ -8648,20 +8465,17 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Matrices for the homalg project",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-05"
   },
   "modisom": {
     "AbstractHTML": "The <span class=\"pkgname\">ModIsom</span> package contains various methods for computing with nilpotent associative algebras. In particular, it contains a method to determine the automorphism group and to test isomorphis of such algebras over finite fields and of modular group algebras of finite p-groups, and it contains a nilpotent quotient algorithm for finitely presented associative algebras and a method to determine Kurosh algebras.",
-    "AcceptDate": "11/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/modisom/releases/download/v2.5.3/modisom-2.5.3",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading ModIsom 2.5.3... \n",
-    "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
     "Date": "09/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -8731,7 +8545,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/modisom"
     },
-    "Status": "accepted",
     "Subtitle": "Computing automorphisms and checking isomorphisms for modular group algebras of finite p-groups",
     "TestFile": "tst/testall.g",
     "Version": "2.5.3"
@@ -8825,7 +8638,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Category R-pres for CAP",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-04"
@@ -8966,7 +8778,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "A homalg based package for the Abelian category of finitely presented modules over computable rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-01"
@@ -9072,7 +8883,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/CAP_project"
     },
-    "Status": "deposited",
     "Subtitle": "Monoidal and monoidal (co)closed categories",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-01"
@@ -9170,20 +8980,17 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/NConvex"
     },
-    "Status": "deposited",
     "Subtitle": "A Gap package to perform polyhedral computations",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-01"
   },
   "nilmat": {
     "AbstractHTML": "The <span class=\"pkgname\">Nilmat</span> package contains methods for checking whether a finitely generated matrix group over a finite field or the field of rational numbers is nilpotent, methods for computing with such nilpotent matrix groups and methods for constructing important classes of such nilpotent matrix groups.",
-    "AcceptDate": "08/2007",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/nilmat/releases/download/v1.4.2/nilmat-1.4.2",
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading Nilmat 1.4.2...\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "05/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9260,14 +9067,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/nilmat"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with nilpotent matrix groups",
     "TestFile": "tst/testall.g",
     "Version": "1.4.2"
   },
   "nock": {
     "AbstractHTML": "The <span class=\"pkgname\">NoCK</span> package    is used for computing Tolzanos's obstruction    for compact Clifford-Klein forms",
-    "AcceptDate": "07/2019",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/NoCK/releases/download/v1.5/NoCK-1.5",
     "AutoDoc": {
@@ -9279,7 +9084,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nNoCK Package 1.5\nby Maciej Boche\u0144ski, Piotr Jastrz\u0119bski, Anna Szczepkowska, Aleksy Tralle, Artur Woike.\n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "30/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9385,7 +9189,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/NoCK"
     },
-    "Status": "accepted",
     "Subtitle": "Computing obstruction for the existence of compact Clifford-Klein form",
     "SupportEmail": "piojas@matman.uwm.edu.pl",
     "TestFile": "tst/testall.g",
@@ -9459,14 +9262,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/NormalizInterface"
     },
-    "Status": "deposited",
     "Subtitle": "GAP wrapper for Normaliz",
     "TestFile": "tst/testall.g",
     "Version": "1.3.4"
   },
   "nq": {
     "AbstractHTML": "This package provides access to the ANU nilpotent quotient program for computing nilpotent factor groups of finitely presented groups.",
-    "AcceptDate": "01/2003",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/nq/releases/download/v2.5.8/nq-2.5.8",
     "AutoDoc": {
@@ -9477,7 +9278,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "Loading nq 2.5.8 (Nilpotent Quotient Algorithm)\n  by Werner Nickel\n  maintained by Max Horn (horn@mathematik.uni-kl.de)\n",
-    "CommunicatedBy": "Joachim Neub\u00fcser (RWTH Aachen)",
     "Date": "04/04/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -9549,19 +9349,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/nq"
     },
-    "Status": "accepted",
     "Subtitle": "Nilpotent Quotients of Finitely Presented Groups",
     "TestFile": "tst/testall.g",
     "Version": "2.5.8"
   },
   "numericalsgps": {
     "AbstractHTML": "The <span class=\"pkgname\">NumericalSgps</span> package, is a package to compute with numerical semigroups.",
-    "AcceptDate": "05/2015",
     "ArchiveFormats": ".tar.gz .zip",
     "ArchiveURL": "https://github.com/gap-packages/numericalsgps/releases/download/v1.3.1/NumericalSgps-1.3.1",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading  NumericalSgps 1.3.1\nFor help, type: ?NumericalSgps: \nTo gain profit from other packages, please refer to chapter\n'External Packages' in the manual, or type: ?NumSgpsUse \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "27/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9746,19 +9543,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/numericalsgps"
     },
-    "Status": "accepted",
     "Subtitle": "A package for numerical semigroups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.1"
   },
   "openmath": {
     "AbstractHTML": "This package provides an <a href=\"http://www.openmath.org/\">OpenMath</a> phrasebook for <span class=\"pkgname\">GAP</span>. This package allows <span class=\"pkgname\">GAP</span> users to import and export mathematical objects encoded in OpenMath, for the purpose of exchanging them with other applications that are OpenMath enabled.",
-    "AcceptDate": "08/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/openmath/releases/download/v11.5.1/OpenMath-11.5.1",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "29/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -9840,7 +9634,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/openmath"
     },
-    "Status": "accepted",
     "Subtitle": "OpenMath functionality in GAP",
     "TestFile": "tst/testall.g",
     "Version": "11.5.1"
@@ -9940,7 +9733,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/orb"
     },
-    "Status": "deposited",
     "Subtitle": "Methods to enumerate orbits",
     "TestFile": "tst/testall.g",
     "Version": "4.9.0"
@@ -10002,7 +9794,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/PackageManager"
     },
-    "Status": "deposited",
     "Subtitle": "Easily download and install GAP packages",
     "TestFile": "tst/test-without-texlive.g",
     "Version": "1.3.2"
@@ -10095,18 +9886,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/PatternClass"
     },
-    "Status": "deposited",
     "Subtitle": "A permutation pattern class package",
     "TestFile": "tst/testall.g",
     "Version": "2.4.3"
   },
   "permut": {
     "AbstractHTML": "This package provides functions for computing with permutability in finite groups.",
-    "AcceptDate": "04/2014",
     "ArchiveFormats": ".tar.gz .tar.bz2 .zip",
     "ArchiveURL": "https://github.com/gap-packages/permut/releases/download/v2.0.4/permut-2.0.4",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Alice Niemeyer (Perth)",
     "Date": "27/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10186,7 +9974,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/permut"
     },
-    "Status": "accepted",
     "Subtitle": "A package to deal with permutability in finite groups",
     "SupportEmail": "Ramon.Esteban@uv.es",
     "TestFile": "tst/testall.g",
@@ -10194,7 +9981,6 @@
   },
   "polenta": {
     "AbstractHTML": "The <span class=\"pkgname\">Polenta</span> package provides  methods to compute polycyclic presentations of matrix groups (finite or infinite). As a by-product, this package gives some functionality to compute certain module series for modules of solvable groups. For example, if G is a rational polycyclic matrix group, then we can compute the radical series of the natural Q[G]-module Q^d.",
-    "AcceptDate": "08/2005",
     "ArchiveFormats": ".tar.gz .tar.bz2",
     "ArchiveURL": "https://github.com/gap-packages/polenta/releases/download/v1.3.10/polenta-1.3.10",
     "AutoDoc": {
@@ -10205,7 +9991,6 @@
     },
     "Autoload": true,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "29/03/2022",
     "Dependencies": {
       "GAP": ">= 4.7",
@@ -10282,14 +10067,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polenta"
     },
-    "Status": "accepted",
     "Subtitle": "Polycyclic presentations for matrix groups",
     "TestFile": "tst/testall.g",
     "Version": "1.3.10"
   },
   "polycyclic": {
     "AbstractHTML": "This package provides various algorithms for computations with polycyclic groups defined by polycyclic presentations.",
-    "AcceptDate": "01/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/polycyclic/releases/download/v2.16/polycyclic-2.16",
     "AutoDoc": {
@@ -10299,7 +10082,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "25/07/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10400,7 +10182,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polycyclic"
     },
-    "Status": "accepted",
     "Subtitle": "Computation with polycyclic groups",
     "TestFile": "tst/testall.g",
     "Version": "2.16"
@@ -10476,7 +10257,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/polymaking"
     },
-    "Status": "deposited",
     "Subtitle": "Interfacing the geometry software polymake",
     "TestFile": "tst/testall.g",
     "Version": "0.8.6"
@@ -10567,7 +10347,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/primgrp"
     },
-    "Status": "deposited",
     "Subtitle": "GAP Primitive Permutation Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "3.4.2"
@@ -10629,7 +10408,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/profiling"
     },
-    "Status": "deposited",
     "Subtitle": "Line by line profiling and code coverage for GAP",
     "TestFile": "tst/testall.g",
     "Version": "2.5.1"
@@ -10703,14 +10481,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/qpa"
     },
-    "Status": "deposited",
     "Subtitle": "Quivers and Path Algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.34"
   },
   "quagroup": {
     "AbstractHTML": "The package <span class=\"pkgname\">QuaGroup</span> contains                  functionality for working with quantized enveloping algebras                 of finite-dimensional semisimple Lie algebras.",
-    "AcceptDate": "10/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/quagroup/releases/download/v1.8.3/quagroup-1.8.3",
     "AutoDoc": {
@@ -10721,7 +10497,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "     |                                                                 \n     |          QuaGroup 1.8.3\n     |                                                                 \n-----------     A package for dealing with quantized enveloping algebras\n     |                                                                 \n     |          Willem de Graaf                                        \n     |          degraaf@science.unitn.it                               \n\n",
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "10/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10775,19 +10550,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/quagroup"
     },
-    "Status": "accepted",
     "Subtitle": "Computations with quantum groups",
     "TestFile": "tst/testall.g",
     "Version": "1.8.3"
   },
   "radiroot": {
     "AbstractHTML": "The <span class=\"pkgname\">RadiRoot</span> package installs a method to    display the roots of a rational polynomial as radicals if it is solvable.",
-    "AcceptDate": "02/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/radiroot/releases/download/v2.9/radiroot-2.9",
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Edmund Robertson (St Andrews)",
     "Date": "01/03/2022",
     "Dependencies": {
       "ExternalConditions": [
@@ -10847,14 +10619,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/radiroot"
     },
-    "Status": "accepted",
     "Subtitle": "Roots of a Polynomial as Radicals",
     "TestFile": "tst/testall.g",
     "Version": "2.9"
   },
   "rcwa": {
     "AbstractHTML": "This package provides implementations of algorithms and methods for computation in certain infinite permutation groups.",
-    "AcceptDate": "04/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/rcwa/releases/download/v4.7.0/rcwa-4.7.0",
     "AutoDoc": {
@@ -10866,7 +10636,6 @@
     },
     "AvailabilityTest": null,
     "BannerString": "\nLoading RCWA 4.7.0 ([R]esidue-[C]lass-[W]ise [A]ffine groups)\n  by Stefan Kohl, sk239@st-andrews.ac.uk.\nSee ?RCWA:About for information about the package.\n\n",
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "29/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -10942,18 +10711,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/rcwa"
     },
-    "Status": "accepted",
     "Subtitle": "Residue-Class-Wise Affine Groups",
     "TestFile": "tst/testall.g",
     "Version": "4.7.0"
   },
   "rds": {
     "AbstractHTML": "This package provides functions for the complete enumeration of relative difference sets.",
-    "AcceptDate": "02/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/rds/releases/download/v1.8/rds-1.8",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
     "Date": "21/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11018,7 +10784,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/rds"
     },
-    "Status": "accepted",
     "Subtitle": "A package for searching relative difference sets",
     "TestFile": "tst/testall.g",
     "Version": "1.8"
@@ -11274,7 +11039,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/recog"
     },
-    "Status": "deposited",
     "Subtitle": "A package for constructive recognition of permutation and matrix groups",
     "TestFile": "tst/testquick.g",
     "Version": "1.4.2"
@@ -11354,14 +11118,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/RepnDecomp"
     },
-    "Status": "deposited",
     "Subtitle": "Decompose representations of finite groups into irreducibles",
     "TestFile": "tst/testall.g",
     "Version": "1.2.1"
   },
   "repsn": {
     "AbstractHTML": "The package provides <span class=\"pkgname\">GAP</span> functions for computing characteristic zero matrix representations of finite groups.",
-    "AcceptDate": "05/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/repsn/releases/download/v3.1.0/repsn-3.1.0",
     "AutoDoc": {
@@ -11370,7 +11132,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Charles Wright (Eugene)",
     "Date": "22/02/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11427,7 +11188,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/repsn"
     },
-    "Status": "accepted",
     "Subtitle": "Constructing representations of finite groups",
     "TestFile": "tst/testall.g",
     "Version": "3.1.0"
@@ -11508,7 +11268,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/resclasses"
     },
-    "Status": "deposited",
     "Subtitle": "Set-Theoretic Computations with Residue Classes",
     "TestFile": "tst/testall.g",
     "Version": "4.7.3"
@@ -11687,7 +11446,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Dictionaries of external rings",
     "TestFile": "tst/testall.g",
     "Version": "2022.10-02"
@@ -11779,14 +11537,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "SCO - Simplicial Cohomology of Orbifolds",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-01"
   },
   "scscp": {
     "AbstractHTML": "This package implements the <a href=\"https://www.openmath.org/standard/scscp/\">Symbolic Computation Software Composability Protocol</a> for the GAP system.",
-    "AcceptDate": "08/2010",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/scscp/releases/download/v2.3.1/SCSCP-2.3.1",
     "Autoload": false,
@@ -11794,7 +11550,6 @@
     "BinaryFiles": [
       "demo/maple2gap.mw"
     ],
-    "CommunicatedBy": "David Joyner (Annapolis)",
     "Date": "22/01/2020",
     "Dependencies": {
       "ExternalConditions": [],
@@ -11870,7 +11625,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/scscp"
     },
-    "Status": "accepted",
     "Subtitle": "Symbolic Computation Software Composability Protocol in GAP",
     "TestFile": "tst/offline.tst",
     "Version": "2.3.1"
@@ -12243,19 +11997,16 @@
       "Type": "git",
       "URL": "https://github.com/semigroups/Semigroups"
     },
-    "Status": "deposited",
     "Subtitle": "A package for semigroups and monoids",
     "TestFile": "tst/teststandard.g",
     "Version": "5.0.2"
   },
   "sglppow": {
     "AbstractHTML": "",
-    "AcceptDate": "08/2016",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sglppow/releases/download/v2.2/sglppow-2.2",
     "AvailabilityTest": null,
     "BannerString": "----------------------------------------------------------------\nLoading SglPPow 2.2\nby Michael Vaughan-Lee and Bettina Eick \n----------------------------------------------------------------\n",
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "05/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12322,7 +12073,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sglppow"
     },
-    "Status": "accepted",
     "Subtitle": "Database of groups of prime-power order for some prime-powers",
     "TestFile": "tst/testall.g",
     "Version": "2.2"
@@ -12393,14 +12143,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sgpviz"
     },
-    "Status": "deposited",
     "Subtitle": "A package for semigroup visualization",
     "TestFile": "tst/testall.g",
     "Version": "0.999.5"
   },
   "simpcomp": {
     "AbstractHTML": "<span class=\"pkgname\">simpcomp</span> is a <span class=\"pkgname\">GAP</span> package for working with simplicial complexes. It allows the computation of many properties of simplicial complexes (such as the f-, g- and h-vectors, the face lattice, the automorphism group, (co-)homology with explicit basis computation, intersection form, etc.) and provides the user with functions to compute new complexes from old (simplex links and stars, connected sums, cartesian products, handle additions, bistellar flips, etc.). Furthermore, it comes with an extensive library of known triangulations of manifolds and provides the user with the possibility to create own complex libraries.<br /> <span class=\"pkgname\">simpcomp</span> caches computed properties of a simplicial complex, thus avoiding unnecessary computations, internally handles the vertex labeling of the complexes and insures the consistency of a simplicial complex throughout all operations.<br /> <span class=\"pkgname\">simpcomp</span> relies on the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">homology</span> for its homology computation, but also provides the user with an own (co-)homology algorithm in case the packacke <span class=\"pkgname\">homology</span> is not available. For automorphism group computation the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">GRAPE</span> is used, which in turn uses the program <tt>nauty</tt> by Brendan McKay. An internal automorphism group calculation algorithm in used as fallback if the <span class=\"pkgname\">GRAPE</span> package is not available.",
-    "AcceptDate": "11/2013",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/simpcomp-team/simpcomp/releases/download/v2.1.14/simpcomp-2.1.14",
     "AutoDoc": {
@@ -12414,7 +12162,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading simpcomp 2.1.14\nby F. Effenberger and J. Spreer\nhttps://github.com/simpcomp-team/simpcomp\n",
-    "CommunicatedBy": "Graham Ellis (Galway)",
     "Date": "15/03/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12515,7 +12262,6 @@
       "Type": "git",
       "URL": "https://github.com/simpcomp-team/simpcomp"
     },
-    "Status": "accepted",
     "Subtitle": "A GAP toolbox for simplicial complexes",
     "TestFile": "tst/simpcomp.tst",
     "Version": "2.1.14"
@@ -12592,14 +12338,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/singular"
     },
-    "Status": "deposited",
     "Subtitle": "A GAP interface to Singular",
     "TestFile": "tst/testall.g",
     "Version": "2022.09.23"
   },
   "sla": {
     "AbstractHTML": "The package <span class=\"pkgname\">SLA</span> contains                  functionality for working with simple Lie algebras,",
-    "AcceptDate": "01/2016",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sla/releases/download/v1.5.3/sla-1.5.3",
     "AutoDoc": {
@@ -12610,7 +12354,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Leonard Soicher (QMUL)",
     "Date": "15/11/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12670,18 +12413,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sla"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with simple Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.5.3"
   },
   "smallgrp": {
     "AbstractHTML": "The <span class=\"smallgrp\">SmallGrp</span> package provides the library of groups of certain \"small\" orders. The groups are sorted by their orders and they are listed up to isomorphism; that is, for each of the available orders a complete and irredundant list of isomorphism type representatives of groups is given.",
-    "AcceptDate": "02/2002",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/SmallGrp/releases/download/v1.5/SmallGrp-1.5",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Newman (Canberra)",
     "Date": "06/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12758,7 +12498,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/SmallGrp"
     },
-    "Status": "accepted",
     "Subtitle": "The GAP Small Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "1.5"
@@ -12838,19 +12577,16 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/smallsemi"
     },
-    "Status": "deposited",
     "Subtitle": "A library of small semigroups",
     "TestFile": "tst/testall.g",
     "Version": "0.6.13"
   },
   "sonata": {
     "AbstractHTML": "The <span class=\"pkgname\">SONATA</span> package provides methods for     the construction and analysis of finite nearrings.",
-    "AcceptDate": "04/2003",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sonata/releases/download/v2.9.5/sonata-2.9.5",
     "AvailabilityTest": null,
     "BannerString": "\n  ___________________________________________________________________________\n /        ___\n||       /   \\                 /\\    Version 2.9.5\n||      ||   ||  |\\    |      /  \\               /\\       Erhard Aichinger\n \\___   ||   ||  |\\\\   |     /____\\_____________/__\\      Franz Binder\n     \\  ||   ||  | \\\\  |    /      \\     ||    /    \\     Juergen Ecker\n     ||  \\___/   |  \\\\ |   /        \\    ||   /      \\    Peter Mayr\n     ||          |   \\\\|  /          \\   ||               Christof Noebauer\n \\___/           |    \\|                 ||\n\n System    Of   Nearrings     And      Their Applications\n Info: https://gap-packages.github.io/sonata/\n\n",
-    "CommunicatedBy": "Charles R.B. Wright (Univ. of Oregon)",
     "Date": "14/10/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -12957,14 +12693,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sonata"
     },
-    "Status": "accepted",
     "Subtitle": "System of nearrings and their applications",
     "TestFile": "tst/testall.g",
     "Version": "2.9.5"
   },
   "sophus": {
     "AbstractHTML": "",
-    "AcceptDate": "10/2004",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/sophus/releases/download/v1.27/sophus-1.27",
     "AutoDoc": {
@@ -12975,7 +12709,6 @@
       }
     },
     "AvailabilityTest": null,
-    "CommunicatedBy": "Olexandr Konovalov (Zaporizhzhia)",
     "Date": "09/08/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13035,7 +12768,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/sophus"
     },
-    "Status": "accepted",
     "Subtitle": "Computing in nilpotent Lie algebras",
     "TestFile": "tst/testall.g",
     "Version": "1.27"
@@ -13116,7 +12848,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/spinsym"
     },
-    "Status": "deposited",
     "Subtitle": "Brauer tables of spin-symmetric groups",
     "TestFile": "tst/testall.tst",
     "Version": "1.5.2"
@@ -13182,18 +12913,15 @@
       "Type": "git",
       "URL": "https://github.com/frankluebeck/StandardFF"
     },
-    "Status": "dev",
     "Subtitle": "Standard finite fields and cyclic generators",
     "TestFile": "tst/testall.g",
     "Version": "0.9.4"
   },
   "symbcompcc": {
     "AbstractHTML": "The <span class=\"pkgname\">SymbCompCC</span> package computes with parametrised presentations for finite p-groups of fixed coclass.",
-    "AcceptDate": "11/2011",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/SymbCompCC/releases/download/v1.3.2/SymbCompCC-1.3.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Mike Newman (Canberra, Australia)",
     "Date": "10/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13252,7 +12980,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/SymbCompCC"
     },
-    "Status": "accepted",
     "Subtitle": "Computing with parametrised presentations for p-groups of fixed coclass",
     "TestFile": "tst/testall.g",
     "Version": "1.3.2"
@@ -13335,7 +13062,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/Thelma"
     },
-    "Status": "deposited",
     "Subtitle": "THreshold ELements, Modeling and Applications",
     "TestFile": "tst/testall.g",
     "Version": "1.3"
@@ -13427,7 +13153,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/tomlib"
     },
-    "Status": "deposited",
     "Subtitle": "The GAP Library of Tables of Marks",
     "TestFile": "tst/testall.g",
     "Version": "1.2.9"
@@ -13517,14 +13242,12 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/homalg_project"
     },
-    "Status": "deposited",
     "Subtitle": "Special methods and knowledge propagation tools",
     "TestFile": "tst/testall.g",
     "Version": "2022.09-08"
   },
   "toric": {
     "AbstractHTML": "<span class=\"pkgname\">toric</span> is a <span class=\"pkgname\">GAP</span>package for computing with toric varieties.",
-    "AcceptDate": "10/2005",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/toric/releases/download/v1.9.5/Toric-1.9.5",
     "AutoDoc": {
@@ -13535,7 +13258,6 @@
     },
     "Autoload": false,
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "07/10/2019",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13593,7 +13315,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/toric"
     },
-    "Status": "accepted",
     "Subtitle": "toric varieties and some combinatorial geometry computations",
     "TestFile": "tst/testall.g",
     "Version": "1.9.5"
@@ -13706,7 +13427,6 @@
       "Type": "git",
       "URL": "https://github.com/homalg-project/ToricVarieties_project"
     },
-    "Status": "deposited",
     "Subtitle": "A package to handle toric varieties",
     "TestFile": "tst/testall.g",
     "Version": "2022.07.13"
@@ -13762,19 +13482,16 @@
       "Type": "git",
       "URL": "https://github.com/hulpke/transgrp"
     },
-    "Status": "deposited",
     "Subtitle": "Transitive Groups Library",
     "TestFile": "tst/testall.g",
     "Version": "3.6.3"
   },
   "ugaly": {
     "AbstractHTML": "<span class=\"pkgname\">UGALY</span> (Universal Groups Acting LocallY) is a <span class=\"pkgname\">GAP</span> package that provides methods to create, analyse and find local actions of generalised universal groups acting on locally finite regular trees, following Burger-Mozes and Tornier.",
-    "AcceptDate": "07/2021",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/UGALY/releases/download/v4.0.3/UGALY-4.0.3",
     "AvailabilityTest": null,
     "BannerString": "\nVersion 4.0.3\n __  __     ______     ______     __         __  __    \n/\\ \\/\\ \\   /\\  ___\\   /\\  __ \\   /\\ \\       /\\ \\_\\ \\   \n\\ \\ \\_\\ \\  \\ \\ \\__ \\  \\ \\  __ \\  \\ \\ \\____  \\ \\____ \\  by Khalil Hannouch\n \\ \\_____\\  \\ \\_____\\  \\ \\_\\ \\_\\  \\ \\_____\\  \\/\\_____\\   and Stephan Tornier\n  \\/_____/   \\/_____/   \\/_/\\/_/   \\/_____/   \\/_____/ \n                                                       \n Universal      Groups      Acting        LocallY    \n",
-    "CommunicatedBy": "Laurent Bartholdi (G\u00f6ttingen)",
     "Date": "14/07/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13842,7 +13559,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/UGALY"
     },
-    "Status": "accepted",
     "Subtitle": "Universal Groups Acting LocallY",
     "TestFile": "tst/testall.g",
     "Version": "4.0.3"
@@ -13910,18 +13626,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/unipot"
     },
-    "Status": "deposited",
     "Subtitle": "Computing with elements of unipotent subgroups of Chevalley groups",
     "TestFile": "tst/testall.g",
     "Version": "1.5"
   },
   "unitlib": {
     "AbstractHTML": "The <span class=\"pkgname\">UnitLib</span> package extends the <span class=\"pkgname\">LAGUNA</span> package and provides the library of normalized unit groups of modular group algebras of all finite p-groups of order less than 243 over the field of p elements.",
-    "AcceptDate": "03/2007",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/unitlib/releases/download/v4.1.0/unitlib-4.1.0",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Bettina Eick (Braunschweig)",
     "Date": "26/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -13997,7 +13710,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/unitlib"
     },
-    "Status": "accepted",
     "Subtitle": "Library of normalized unit groups of modular group algebras",
     "TestFile": "tst/testall.g",
     "Version": "4.1.0"
@@ -14130,7 +13842,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/utils"
     },
-    "Status": "deposited",
     "Subtitle": "Utility functions in GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.77"
@@ -14199,7 +13910,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/uuid"
     },
-    "Status": "deposited",
     "Subtitle": "RFC 4122 UUIDs",
     "TestFile": "tst/testall.g",
     "Version": "0.7"
@@ -14280,18 +13990,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/walrus"
     },
-    "Status": "deposited",
     "Subtitle": "A new approach to proving hyperbolicity",
     "TestFile": "tst/testall.g",
     "Version": "0.9991"
   },
   "wedderga": {
     "AbstractHTML": "<span class=\"pkgname\">Wedderga</span> is the package to compute the simple components of the Wedderburn decomposition of semisimple group algebras of finite groups over finite fields and over subfields of finite cyclotomic extensions of the rationals. It also contains functions that produce the primitive central idempotents of semisimple group algebras and functions for computing Schur indices. Other functions of <span class=\"pkgname\">Wedderga</span> allow one to construct crossed products over a group with coefficients in an associative ring with identity and the multiplication determined by a given action and twisting.",
-    "AcceptDate": "01/2008",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/wedderga/releases/download/v4.10.2/wedderga-4.10.2",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hiss (Aachen)",
     "Date": "29/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14439,18 +14146,15 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/wedderga"
     },
-    "Status": "accepted",
     "Subtitle": "Wedderburn Decomposition of Group Algebras",
     "TestFile": "tst/testall.g",
     "Version": "4.10.2"
   },
   "xgap": {
     "AbstractHTML": "The <span class=\"pkgname\">XGAP</span> package allows to use graphics in GAP.",
-    "AcceptDate": "07/1999",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xgap/releases/download/v4.31/xgap-4.31",
     "AvailabilityTest": null,
-    "CommunicatedBy": "Gerhard Hi\u00df (Aachen)",
     "Date": "17/02/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14513,14 +14217,12 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xgap"
     },
-    "Status": "accepted",
     "Subtitle": "a graphical user interface for GAP",
     "TestFile": "tst/testall.g",
     "Version": "4.31"
   },
   "xmod": {
     "AbstractHTML": "The <span class=\"pkgname\">XMod</span> package provides a collection   of functions for computing with crossed modules and cat1-groups, their derivations and sections, morphisms of these structures, and higher-dimensional generalisations.",
-    "AcceptDate": "12/1996",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xmod/releases/download/v2.88/XMod-2.88",
     "AutoDoc": {
@@ -14533,7 +14235,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "Loading XMod 2.88 (methods for crossed modules and cat1-groups)\nby Chris Wensley (https://github.com/cdwensley),\n with contributions from:\n    Murat Alp (muratalp@nigde.edu.tr),\n    Alper Odabas (aodabas@ogu.edu.tr),\nand Enver Uslu.\n-----------------------------------------------------------------------------\n",
-    "CommunicatedBy": "Derek Holt (Warwick)",
     "Date": "28/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14642,7 +14343,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmod"
     },
-    "Status": "accepted",
     "Subtitle": "Crossed Modules and Cat1-Groups",
     "SupportEmail": "c.d.wensley@bangor.ac.uk",
     "TestFile": "tst/testall.g",
@@ -14650,7 +14350,6 @@
   },
   "xmodalg": {
     "AbstractHTML": "The <span class=\"pkgname\">XModAlg</span> package provides a collection of functions for computing with crossed modules and cat1-algebras and morphisms of these structures.",
-    "AcceptDate": "",
     "ArchiveFormats": ".tar.gz",
     "ArchiveURL": "https://github.com/gap-packages/xmodalg/releases/download/v1.22/XModAlg-1.22",
     "AutoDoc": {
@@ -14663,7 +14362,6 @@
     "Autoload": false,
     "AvailabilityTest": null,
     "BannerString": "-----------------------------------------------------------------------------\nLoading XModAlg 1.22 (29/04/2022) for GAP 4.11 \nMethods for crossed modules of commutative algebras and cat1-algebras\nby Zekeriya Arvasi (zarvasi@ogu.edu.tr) and Alper Odabas (aodabas@ogu.edu.tr).\n-----------------------------------------------------------------------------\n",
-    "CommunicatedBy": "",
     "Date": "29/04/2022",
     "Dependencies": {
       "ExternalConditions": [],
@@ -14730,7 +14428,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/xmodalg"
     },
-    "Status": "deposited",
     "Subtitle": "Crossed Modules and Cat1-Algebras",
     "SupportEmail": "aodabas@ogu.edu.tr",
     "TestFile": "tst/testall.g",
@@ -14808,7 +14505,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/YangBaxter"
     },
-    "Status": "deposited",
     "Subtitle": "Combinatorial Solutions for the Yang-Baxter equation",
     "TestFile": "tst/testall.g",
     "Version": "0.10.1"
@@ -14895,7 +14591,6 @@
       "Type": "git",
       "URL": "https://github.com/gap-packages/ZeroMQInterface"
     },
-    "Status": "deposited",
     "Subtitle": "ZeroMQ bindings for GAP",
     "TestFile": "tst/testall.g",
     "Version": "0.14"

--- a/_data/package-infos/4-12-2.json
+++ b/_data/package-infos/4-12-2.json
@@ -64,20 +64,17 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "A link to 4ti2",
         "TestFile": "tst/testall.g",
         "Version": "2022.09-01"
     },
     "ace": {
         "AbstractHTML": "The <span class=\"pkgname\">ACE</span> package provides both an    interactive and non-interactive interface with the Todd-Coxeter coset   enumeration functions of the ACE (Advanced Coset Enumerator) C program.",
-        "AcceptDate": "04/2001",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "17b8e969a20a1c1bb0dae75ead60dd463b41a59e688d913e30999b2f2248b7f7",
         "ArchiveURL": "https://github.com/gap-packages/ace/releases/download/v5.6.1/ace-5.6.1",
         "AvailabilityTest": null,
         "BannerString": "---------------------------------------------------------------------------\nLoading    ACE (Advanced Coset Enumerator) 5.6.1\nGAP code by Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)\n       Alexander Hulpke (https://www.math.colostate.edu/~hulpke)\n           [uses ACE binary (C code program) version: 3.001]\nC code by  George Havas (http://staff.itee.uq.edu.au/havas)\n           Colin Ramsay <cram@itee.uq.edu.au>\nCo-maintainer: Max Horn <horn@mathematik.uni-kl.de>\n\n                 For help, type: ?ACE\n---------------------------------------------------------------------------\n",
-        "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
         "Date": "26/09/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -174,19 +171,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/ace"
         },
-        "Status": "accepted",
         "Subtitle": "Advanced Coset Enumerator",
         "TestFile": "tst/aceds.tst",
         "Version": "5.6.1"
     },
     "aclib": {
         "AbstractHTML": "The <span class=\"pkgname\">AClib</span> package contains a library of almost crystallographic groups and a some algorithms to compute with these groups. A group is called almost crystallographic if it is finitely generated nilpotent-by-finite and has no non-trivial finite normal subgroups. Further, an almost crystallographic group is called almost Bieberbach if it is torsion-free. The almost crystallographic groups of Hirsch length 3 and a part of the almost cyrstallographic groups of Hirsch length 4 have been classified by Dekimpe. This classification includes all almost Bieberbach groups of Hirsch lengths 3 or 4. The AClib package gives access to this classification; that is, the package contains this library of groups in a computationally useful form. The groups in this library are available in two different representations. First, each of the groups of Hirsch length 3 or 4 has a rational matrix representation of dimension 4 or 5, respectively, and such representations are available in this package. Secondly, all the groups in this libraray are (infinite) polycyclic groups and the package also incorporates polycyclic presentations for them. The polycyclic presentations can be used to compute with the given groups using the methods of the Polycyclic package.",
-        "AcceptDate": "02/2001",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "f672d0aee19f22b411352835a4730a6f88eecad7d79d8452b273f381b03e1a7b",
         "ArchiveURL": "https://github.com/gap-packages/aclib/releases/download/v1.3.2/aclib-1.3.2",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Gerhard Hiss (Aachen)",
         "Date": "28/01/2020",
         "Dependencies": {
             "ExternalConditions": [],
@@ -260,7 +254,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/aclib"
         },
-        "Status": "accepted",
         "Subtitle": "Almost Crystallographic Groups - A Library and Algorithms",
         "TestFile": "tst/testall.g",
         "Version": "1.3.2"
@@ -339,7 +332,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/AGT"
         },
-        "Status": "deposited",
         "Subtitle": "Algebraic Graph Theory",
         "SupportEmail": "rhysjevans00@gmail.com",
         "TestFile": "tst/testall.g",
@@ -347,12 +339,10 @@
     },
     "alnuth": {
         "AbstractHTML": "The <span class=\"pkgname\">Alnuth</span> package provides various methods to compute with number fields which are given by a defining polynomial or by generators. Some of the methods provided in this package are written in <span class=\"pkgname\">GAP</span> code. The other part of the methods is imported from the computer algebra system PARI/GP. Hence this package contains some <span class=\"pkgname\">GAP</span> functions and an interface to some functions in the computer algebra system PARI/GP. The main methods included in <span class=\"pkgname\">Alnuth</span> are: creating a number field, computing its maximal order (using PARI/GP), computing its unit group (using PARI/GP) and a presentation of this unit group, computing the elements of a given norm of the number field (using PARI/GP), determining a presentation for a finitely generated multiplicative subgroup (using PARI/GP), and factoring polynomials defined over number fields (using PARI/GP).",
-        "AcceptDate": "01/2004",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "b474c879dcf28023a80608c1354974337e2e598287e5a81ded5ef5ba3e7d63ca",
         "ArchiveURL": "https://github.com/gap-packages/alnuth/releases/download/v3.2.1/alnuth-3.2.1",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Charles Wright (Eugene)",
         "Date": "05/04/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -436,14 +426,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/alnuth"
         },
-        "Status": "accepted",
         "Subtitle": "Algebraic number theory and an interface to PARI/GP",
         "TestFile": "tst/testall.g",
         "Version": "3.2.1"
     },
     "anupq": {
         "AbstractHTML": "The <span class=\"pkgname\">ANUPQ</span> package provides an interactive    interface to the p-quotient, p-group generation and standard presentation    algorithms of the ANU pq C program.",
-        "AcceptDate": "04/2002",
         "ArchiveFormats": ".tar.gz .tar.bz2",
         "ArchiveSHA256": "9df9f662c4df3b32916c61e0becd2d04162b75150368b2dadc50f1c432ca8579",
         "ArchiveURL": "https://github.com/gap-packages/anupq/releases/download/v3.2.6/anupq-3.2.6",
@@ -454,7 +442,6 @@
         },
         "AvailabilityTest": null,
         "BannerFunction": null,
-        "CommunicatedBy": "Charles Wright (Eugene)",
         "Date": "07/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -538,19 +525,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/anupq"
         },
-        "Status": "accepted",
         "Subtitle": "ANU p-Quotient",
         "TestFile": "tst/testinstall.g",
         "Version": "3.2.6"
     },
     "atlasrep": {
         "AbstractHTML": "The package provides a <span class=\"pkgname\">GAP</span> interface to the <a href=\"http://atlas.math.rwth-aachen.de/Atlas/v3\">Atlas of Group Representations</a>",
-        "AcceptDate": "04/2001",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "4eadbbd5cf67abac81223762243b0046c51ec9b3bb1acf377906b6b6b05f24b7",
         "ArchiveURL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/atlasrep-2.1.6",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Herbert Pahlings (Aachen)",
         "Date": "19/10/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -667,7 +651,6 @@
             }
         ],
         "README_URL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/README.md",
-        "Status": "accepted",
         "Subtitle": "A GAP Interface to the Atlas of Group Representations",
         "TestFile": "tst/testauto.g",
         "Version": "2.1.6"
@@ -789,20 +772,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/AutoDoc"
         },
-        "Status": "deposited",
         "Subtitle": "Generate documentation from GAP source code",
         "TestFile": "tst/testall.g",
         "Version": "2022.10.20"
     },
     "automata": {
         "AbstractHTML": "The <span class=\"pkgname\">Automata</span> package, as its name suggests, is package with algorithms to deal with automata.",
-        "AcceptDate": "09/2004",
         "ArchiveFormats": ".tar.gz .tar.bz2",
         "ArchiveSHA256": "0098035c11d4583055cdc391f6b08aa2603ed3259f605fe5cc5c4ed8adb7b3a7",
         "ArchiveURL": "https://github.com/gap-packages/automata/releases/download/v1.15/automata-1.15",
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "Edmund Robertson (St. Andrews)",
         "Date": "20/03/2022",
         "Dependencies": {
             "GAP": ">=4.8",
@@ -872,21 +852,18 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/automata"
         },
-        "Status": "accepted",
         "Subtitle": "A package on automata",
         "TestFile": "tst/testall.g",
         "Version": "1.15"
     },
     "automgrp": {
         "AbstractHTML": "The <span class=\"pkgname\">AutomGrp</span> package provides methods for computations with groups and semigroups generated by finite automata or given by wreath recursion, as well as with their finitely generated subgroups and elements.",
-        "AcceptDate": "03/2016",
         "ArchiveFormats": ".tar.gz .tar.bz2",
         "ArchiveSHA256": "cae7ef133b7e07c45e47e7ef27a94cb1655999c21dd4fd33fc56f369b5e0a5a0",
         "ArchiveURL": "https://github.com/gap-packages/automgrp/releases/download/v1.3.2/automgrp-1.3.2",
         "Autoload": true,
         "AvailabilityTest": null,
         "BannerString": "----------------------------------------------------------------\n     ^                                    ___                   \n    / \\                                  /   \\                  \n   /   \\           _______  ___         ||        ___   __      \n  /_____\\   ||  ||    |    /   \\  |\\ /| ||   __ |/   | |  \\    \n /       \\  ||  ||    |   ||   || | V | ||   || |      |__/    \n/         \\  \\__/     |    \\___/  |   |  \\___/  |      |        \n                                                                \nLoading  AutomGrp 1.3.2 (Automata Groups and Semigroups)\nby Yevgen Muntyan (muntyan@fastmail.fm)\n   Dmytro Savchuk (http://savchuk.myweb.usf.edu/)\nHomepage: https://gap-packages.github.io/automgrp\n----------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
         "Date": "30/09/2019",
         "Dependencies": {
             "ExternalConditions": [],
@@ -958,19 +935,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/automgrp"
         },
-        "Status": "accepted",
         "Subtitle": "Automata groups",
         "TestFile": "tst/testall.g",
         "Version": "1.3.2"
     },
     "autpgrp": {
         "AbstractHTML": "The <span class=\"pkgname\">AutPGrp</span> package introduces a new function to compute the automorphism group of a finite $p$-group. The underlying algorithm is a refinement of the methods described in O'Brien (1995). In particular, this implementation is more efficient in both time and space requirements and hence has a wider range of applications than the ANUPQ method. Our package is written in GAP code and it makes use of a number of methods from the GAP library such as the MeatAxe for matrix groups and permutation group functions. We have compared our method to the others available in GAP. Our package usually out-performs all but the method designed for finite abelian groups. We note that our method uses the small groups library in certain cases and hence our algorithm is more effective if the small groups library is installed.",
-        "AcceptDate": "09/2000",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "ade6c143b5b9b03c5c4c5b121732287146aa79d40de53d5383383c76f8cc1eb2",
         "ArchiveURL": "https://github.com/gap-packages/autpgrp/releases/download/v1.11/autpgrp-1.11",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Derek F. Holt (Warwick)",
         "Date": "05/08/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -1042,7 +1016,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/autpgrp"
         },
-        "Status": "accepted",
         "Subtitle": "Computing the Automorphism Group of a p-Group",
         "TestFile": "tst/testall.g",
         "Version": "1.11"
@@ -1124,7 +1097,6 @@
             }
         ],
         "README_URL": "https://www.math.rwth-aachen.de/~Browse/README",
-        "Status": "deposited",
         "Subtitle": "browsing applications and ncurses interface",
         "Version": "1.8.19"
     },
@@ -1213,14 +1185,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/CAP_project"
         },
-        "Status": "deposited",
         "Subtitle": "Categories, Algorithms, Programming",
         "TestFile": "tst/testall.g",
         "Version": "2022.12-11"
     },
     "caratinterface": {
         "AbstractHTML": "This package provides <span class=\"pkgname\">GAP</span> interface routines to some of the stand-alone programs of <a href=\"https://lbfm-rwth.github.io/carat\">CARAT</a>, a package for the computation with crystallographic groups. CARAT is to a large extent complementary to the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">Cryst</span>. In particular, it provides routines for the computation of normalizers and conjugators of finite unimodular groups in GL(n,Z), and routines for the computation of Bravais groups, which are all missing in <span class=\"pkgname\">Cryst</span>. A catalog of Bravais groups up to dimension 6 is also provided.",
-        "AcceptDate": "02/2000",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "4f3c843f64175706ece12b826b970465d3e2bd9afc153f75603948ef7f05dd9e",
         "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CaratInterface/CaratInterface-2.3.4",
@@ -1230,7 +1200,6 @@
             "doc/manual.dvi",
             "carat.tgz"
         ],
-        "CommunicatedBy": "Herbert Pahlings (Aachen)",
         "Date": "29/07/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -1284,7 +1253,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/caratinterface"
         },
-        "Status": "accepted",
         "Subtitle": "Interface to CARAT, a crystallographic groups package",
         "SupportEmail": "gaehler@math.uni-bielefeld.de",
         "TestFile": "tst/testall.g",
@@ -1350,19 +1318,16 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/CddInterface"
         },
-        "Status": "deposited",
         "Subtitle": "Gap interface to Cdd package",
         "TestFile": "tst/testall.g",
         "Version": "2022.11.01"
     },
     "circle": {
         "AbstractHTML": "The <span class=\"pkgname\">Circle</span> package provides functionality for computations in adjoint groups of finite associative rings. It allows to construct circle objects that will respect the circle multiplication r*s=r+s+rs, create multiplicative groups, generated by such objects, and compute groups of elements, invertible with respect to this operation. Also it may serve as an example of extending the GAP system with new multiplicative objects.",
-        "AcceptDate": "01/2008",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "77a152f718fed804b638992dcd0d66c488e97b08623281106ca4dce1f5c97a31",
         "ArchiveURL": "https://github.com/gap-packages/circle/releases/download/v1.6.5/circle-1.6.5",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "27/04/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -1429,7 +1394,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/circle"
         },
-        "Status": "accepted",
         "Subtitle": "Adjoint groups of finite rings",
         "TestFile": "tst/testall.g",
         "Version": "1.6.5"
@@ -1524,20 +1488,17 @@
             "Type": "git",
             "URL": "https://github.com/hulpke/magmapresentations/"
         },
-        "Status": "deposited",
         "Subtitle": "Classical Group Presentations",
         "TestFile": "tst/testall.g",
         "Version": "1.22"
     },
     "cohomolo": {
         "AbstractHTML": "The <span class=\"pkgname\">cohomolo</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for computing Schur multipliers and covering groups of finite groups   and first and second cohomology groups of finite groups acting   on finite modules",
-        "AcceptDate": "01/1970",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "4c114eea27e54c26001f428ac6b4b92ca9620869dda367112fd1cfbf98e5b5e1",
         "ArchiveURL": "https://github.com/gap-packages/cohomolo/releases/download/v1.6.10/cohomolo-1.6.10",
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "unknown (unknown)",
         "Date": "30/03/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -1595,19 +1556,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/cohomolo"
         },
-        "Status": "accepted",
         "Subtitle": "Cohomology groups of finite groups on finite modules",
         "TestFile": "tst/testall.g",
         "Version": "1.6.10"
     },
     "congruence": {
         "AbstractHTML": "The <span class=\"pkgname\">Congruence </span> package provides functions to construct several types of canonical congruence subgroups in SL_2(Z), and also intersections of a finite number of such subgroups. Furthermore, it implements the algorithm for generating Farey symbols for congruence subgroups and using them to produce a system of independent generators for these subgroups",
-        "AcceptDate": "09/2014",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "fe4d24dda39e6bccc170a6d55e690bc22b30e457101221f452a3cd7a48a05627",
         "ArchiveURL": "https://github.com/gap-packages/congruence/releases/download/v1.2.4/congruence-1.2.4",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Graham Ellis (Galway)",
         "Date": "27/04/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -1694,14 +1652,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/congruence"
         },
-        "Status": "accepted",
         "Subtitle": "Congruence subgroups of SL(2,Integers)",
         "TestFile": "tst/testall.g",
         "Version": "1.2.4"
     },
     "corelg": {
         "AbstractHTML": "The package <span class=\"pkgname\">CoReLG</span> contains functionality for working with real semisimple Lie algebras.",
-        "AcceptDate": "01/2014",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "06ee7fc8faf147e38f61a01c0178b061ed37f922dce4f065c6451f179865185f",
         "ArchiveURL": "https://github.com/gap-packages/corelg/releases/download/v1.56/corelg-1.56",
@@ -1714,7 +1670,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Bettina Eick (Braunschweig)",
         "Date": "24/02/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -1788,14 +1743,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/corelg"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with real Lie algebras",
         "TestFile": "tst/testall.g",
         "Version": "1.56"
     },
     "crime": {
         "AbstractHTML": "This package computes the cohomology rings of finite p-groups, induced maps, and Massey products.",
-        "AcceptDate": "10/2006",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "c6630c5d5385caa3a0e470599759f8e42bd5f0147eebfee164ca808cec83371e",
         "ArchiveURL": "https://github.com/gap-packages/crime/releases/download/v1.6/crime-1.6",
@@ -1808,7 +1761,6 @@
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "\nThis is CRIME, Version 1.6\n\"Obviously crime pays, or there'd be no crime\".\n                                G. Gordon Liddy\n\n",
-        "CommunicatedBy": "Bettina Eick (Braunschweig)",
         "Date": "17/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -1860,14 +1812,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/crime"
         },
-        "Status": "accepted",
         "Subtitle": "A GAP Package to Calculate Group Cohomology and Massey Products",
         "TestFile": "tst/testall.g",
         "Version": "1.6"
     },
     "crisp": {
         "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">CRISP</span> provides algorithms for computing subgroups of finite soluble groups related to a group class <i>C</i>. In particular, it allows to compute <i>C</i>-radicals and <i>C</i>-injectors for Fitting classes (and Fitting sets) <i>C</i>, <i>C</i>-residuals for formations <i>C</i>, and <i>C</i>-projectors for Schunck classes <i>C</i>. In order to carry out these computations, the group class <i>C</i> must be represented by an algorithm which can decide membership in the group class.</p>  <p>Moreover, <span class=\"pkgname\">CRISP</span> contains algorithms for the computation of normal subgroups invariant under a prescribed set of automorphisms and belonging to a given group class.</p>  <p>This includes an improved method to compute the set of all normal subgroups of a finite soluble group, its characteristic subgroups, minimal normal subgroups and the socle and <i>p</i>-socles for given primes <i>p</i>.",
-        "AcceptDate": "12/2000",
         "ArchiveFormats": ".tar.bz2",
         "ArchiveSHA256": "31a8d37b577208dc22c27b479d391b3bd89ba9dcab528b1570726af57098ccb1",
         "ArchiveURL": "http://www.icm.tu-bs.de/~bhoeflin/crisp/crisp-1.4.6",
@@ -1876,7 +1826,6 @@
         "BinaryFiles": [
             "doc/manual.pdf"
         ],
-        "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
         "Date": "15/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -1932,7 +1881,6 @@
             "Type": "git",
             "URL": "https://github.com/bh11/crisp.git"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with Radicals, Injectors, Schunck classes and Projectors",
         "TestFile": "tst/testall.g",
         "Version": "1.4.6"
@@ -1997,14 +1945,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/crypting"
         },
-        "Status": "deposited",
         "Subtitle": "Hashes and Crypto in GAP",
         "TestFile": "tst/testall.g",
         "Version": "0.10.4"
     },
     "cryst": {
         "AbstractHTML": "This package, previously known as <span class=\"pkgname\">CrystGAP</span>, provides a rich set of methods for the computation with affine crystallographic groups, in particular space groups. Affine crystallographic groups are fully supported both in representations acting from the right or from the left, the latter one being preferred by crystallographers. Functions to determine representatives of all space group types of a given dimension are also provided. Where necessary, <span class=\"pkgname\">Cryst</span> can also make use of functionality provided by the package <span class=\"pkgname\">CaratInterface</span>.",
-        "AcceptDate": "02/2000",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "f784398c06c5ccef550a4ff0767677bdaec3f4dbc744853471ea16accbaacf15",
         "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/Cryst/cryst-4.1.25",
@@ -2013,7 +1959,6 @@
             "doc/manual.pdf",
             "doc/manual.dvi"
         ],
-        "CommunicatedBy": "Herbert Pahlings (Aachen)",
         "Date": "29/07/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -2107,7 +2052,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/cryst"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with crystallographic groups",
         "SupportEmail": "gaehler@math.uni-bielefeld.de",
         "TestFile": "tst/testall.g",
@@ -2115,7 +2059,6 @@
     },
     "crystcat": {
         "AbstractHTML": "This package provides a catalog of crystallographic groups of dimensions 2, 3, and 4 which covers most of the data contained in the book <em>Crystallographic groups of four-dimensional space</em> by H. Brown, R. B&uuml;low, J. Neub&uuml;ser, H. Wondratschek, and H. Zassenhaus (John Wiley, New York, 1978). Methods for the computation with these groups are provided by the package <span class=\"pkgname\">Cryst</span>, which must be installed as well.",
-        "AcceptDate": "02/2000",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "0e2e568ed054c83312e56b52da26955742034814c85609eb69524a1154d8f2bc",
         "ArchiveURL": "https://www.math.uni-bielefeld.de/~gaehler/gap/CrystCat/crystcat-1.1.10",
@@ -2124,7 +2067,6 @@
             "doc/manual.pdf",
             "doc/manual.dvi"
         ],
-        "CommunicatedBy": "Herbert Pahlings (Aachen)",
         "Date": "29/07/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -2187,7 +2129,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/crystcat"
         },
-        "Status": "accepted",
         "Subtitle": "The crystallographic groups catalog",
         "SupportEmail": "gaehler@math.uni-bielefeld.de",
         "TestFile": "tst/testall.g",
@@ -2301,20 +2242,17 @@
             }
         ],
         "README_URL": "https://www.math.rwth-aachen.de/~Thomas.Breuer/ctbllib/README.md",
-        "Status": "deposited",
         "Subtitle": "The GAP Character Table Library",
         "TestFile": "tst/testauto.g",
         "Version": "1.3.4"
     },
     "cubefree": {
         "AbstractHTML": "The <span class=\"pkgname\">Cubefree</span> package contains methods to construct up to isomorphism the groups of a given (reasonable) cubefree order. The main function ConstructAllCFGroups(n) constructs all groups of a given cubefree order n. The function NumberCFGroups(n) counts all groups of a cubefree order n. Furthermore, IrreducibleSubgroupsOfGL(2,q) constructs the irreducible subgroups of GL(2,q), q=p^r, p>=5 prime, up to conjugacy and RewriteAbsolutelyIrreducibleMatrixGroup(G) rewrites the absolutely irreducible matrix group G (over a finite field) over a minimal subfield.",
-        "AcceptDate": "10/2007",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "993f420922b48c9ab4f7e77c6de50041ebcf1cd6d13376a940ecd84684255676",
         "ArchiveURL": "https://github.com/gap-packages/cubefree/releases/download/v1.19/cubefree-1.19",
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "David Joyner (Annapolis)",
         "Date": "21/02/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -2374,7 +2312,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/cubefree"
         },
-        "Status": "accepted",
         "Subtitle": "Constructing the Groups of a Given Cubefree Order",
         "TestFile": "tst/testall.g",
         "Version": "1.19"
@@ -2456,7 +2393,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/curlInterface"
         },
-        "Status": "deposited",
         "Subtitle": "Simple Web Access",
         "TestFile": "tst/testall.g",
         "Version": "2.3.1"
@@ -2538,7 +2474,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/cvec"
         },
-        "Status": "deposited",
         "Subtitle": "Compact vectors over finite fields",
         "TestFile": "tst/testall.g",
         "Version": "2.7.6"
@@ -2640,7 +2575,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/datastructures"
         },
-        "Status": "deposited",
         "Subtitle": "Collection of standard data structures for GAP",
         "TestFile": "tst/testall.g",
         "Version": "0.3.0"
@@ -2715,14 +2649,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/DeepThought"
         },
-        "Status": "deposited",
         "Subtitle": "This package provides functions for computations in finitely generated nilpotent groups based on the Deep Thought algorithm.",
         "TestFile": "tst/testall.g",
         "Version": "1.0.6"
     },
     "design": {
         "AbstractHTML": "<span class=\"pkgname\">DESIGN</span> is a package for constructing, classifying, partitioning, and studying block designs.",
-        "AcceptDate": "08/2006",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "3ac0e3acac08cdec786362aa77192c7fc78df7764c0f9a2b01849238aef75641",
         "ArchiveURL": "https://github.com/gap-packages/design/releases/download/v1.7/design-1.7",
@@ -2731,7 +2663,6 @@
             "doc/manual.dvi",
             "doc/manual.pdf"
         ],
-        "CommunicatedBy": "Akos Seress (Ohio State)",
         "Date": "18/03/2019",
         "Dependencies": {
             "ExternalConditions": [],
@@ -2794,14 +2725,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/design"
         },
-        "Status": "accepted",
         "Subtitle": "The Design Package for GAP",
         "TestFile": "tst/testall.g",
         "Version": "1.7"
     },
     "difsets": {
         "AbstractHTML": "The <span class=\"pkgname\">DifSets</span> package is a         <span class=\"pkgname\">GAP</span> package implementing an algorithm         for enumerating all difference sets up to equivalence in a group.",
-        "AcceptDate": "07/2019",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "9474bd64007006b74087908bc05544fea9e5c7ef085dfdf0109d3142003cb303",
         "ArchiveURL": "https://github.com/dylanpeifer/difsets/releases/download/v2.3.1/difsets-2.3.1",
@@ -2812,7 +2741,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Alexander Hulpke (Colorado State)",
         "Date": "14/09/2019",
         "Dependencies": {
             "GAP": "4.9",
@@ -2870,7 +2798,6 @@
             "Type": "git",
             "URL": "https://github.com/dylanpeifer/difsets"
         },
-        "Status": "accepted",
         "Subtitle": "an algorithm for enumerating all difference sets in a group",
         "SupportEmail": "djp282@cornell.edu",
         "TestFile": "tst/testall.g",
@@ -3235,20 +3162,17 @@
             "Type": "git",
             "URL": "https://github.com/digraphs/Digraphs"
         },
-        "Status": "deposited",
         "Subtitle": "Graphs, digraphs, and multidigraphs in GAP",
         "TestFile": "tst/teststandard.g",
         "Version": "1.6.1"
     },
     "edim": {
         "AbstractHTML": "This package provides  a collection of functions for computing the Smith normal form of integer matrices and some related utilities.",
-        "AcceptDate": "08/1999",
         "ArchiveFormats": ".tar.bz2  .tar.gz   -win.zip",
         "ArchiveSHA256": "d99d9e4a9fdb5e3a8535592d334b5afa99154215753e83f6b3aabbae07ec94f6",
         "ArchiveURL": "https://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/EDIM-1.3.6",
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "Mike Atkinson (St Andrews)",
         "Date": "23/09/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -3304,7 +3228,6 @@
             "Type": "git",
             "URL": "https://github.com/frankluebeck/EDIM"
         },
-        "Status": "accepted",
         "Subtitle": "Elementary Divisors of Integer Matrices",
         "TestFile": "tst/edim.tst",
         "Version": "1.3.6"
@@ -3391,7 +3314,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/example"
         },
-        "Status": "deposited",
         "Subtitle": "Example/Template of a GAP Package",
         "SupportEmail": "obk1@st-andrews.ac.uk",
         "TestFile": "tst/testall.g",
@@ -3506,14 +3428,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "Examples for the GAP Package homalg",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
     },
     "factint": {
         "AbstractHTML": "\nThis package provides routines for factoring integers, in particular:\n<ul>\n  <li>Pollard's <em>p</em>-1</li>\n  <li>Williams' <em>p</em>+1</li>\n  <li>Elliptic Curves Method (ECM)</li>\n  <li>Continued Fraction Algorithm (CFRAC)</li>\n  <li>Multiple Polynomial Quadratic Sieve (MPQS)</li>\n</ul>\nIt also provides access to Richard P. Brent's tables of factors of integers of the form <em>b</em>^<em>k</em> +/- 1.\n",
-        "AcceptDate": "07/1999",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "fdd63f32fc88d7dc035024a9fb30fc2f2cf70747a3c2dae2f168bf89fb48af06",
         "ArchiveURL": "https://github.com/gap-packages/FactInt/releases/download/v1.6.3/FactInt-1.6.3",
@@ -3525,7 +3445,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Mike Atkinson (St. Andrews)",
         "Date": "15/11/2019",
         "Dependencies": {
             "ExternalConditions": [],
@@ -3596,7 +3515,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/FactInt"
         },
-        "Status": "accepted",
         "Subtitle": "Advanced Methods for Factoring Integers",
         "TestFile": "tst/testall.g",
         "Version": "1.6.3"
@@ -3664,20 +3582,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/ferret"
         },
-        "Status": "deposited",
         "Subtitle": "Backtrack Search in Permutation Groups",
         "TestFile": "tst/testall.g",
         "Version": "1.0.9"
     },
     "fga": {
         "AbstractHTML": "The <span class=\"pkgname\">FGA</span> package installs methods for    computations with finitely generated subgroups of free groups and    provides a presentation for their automorphism groups.",
-        "AcceptDate": "05/2005",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "7c9e01ead442441bdf5635ebb9ccf1b75fa9eceae52b4c7957afb54ab9a23507",
         "ArchiveURL": "http://www.icm.tu-bs.de/ag_algebra/software/FGA/FGA-1.4.0",
         "Autoload": true,
         "AvailabilityTest": null,
-        "CommunicatedBy": "Edmund Robertson (St. Andrews)",
         "Date": "23/03/2018",
         "Dependencies": {
             "ExternalConditions": [],
@@ -3724,14 +3639,12 @@
             "Type": "git",
             "URL": "https://github.com/chsievers/fga"
         },
-        "Status": "accepted",
         "Subtitle": "Free Group Algorithms",
         "TestFile": "tst/testall.g",
         "Version": "1.4.0"
     },
     "fining": {
         "AbstractHTML": "<span class=\"pkgname\">FinInG</span> is a package for computation in Finite Incidence Geometry. It provides users with the basic tools to work in  various areas of finite geometry from the realms of projective spaces to the flat  lands of generalised polygons. The algebraic power of GAP is employed, particularly  in its facility with matrix and permutation groups.",
-        "AcceptDate": "11/2017",
         "ArchiveFormats": ".tar.gz .tar.bz2",
         "ArchiveSHA256": "48367ac1d9e0740495c6c2bafeaae96fef9f361d285362051dc30e730997e2fa",
         "ArchiveURL": "https://github.com/gap-packages/FinInG/releases/download/v1.5.4/fining-1.5.4",
@@ -3746,7 +3659,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "---------------------------------------------------------------------\n             ______________       ________      _________            \n             ___  ____/__(_)__________  _/________  ____/            \n             __  /_   __  /__  __ __  / __  __   / __              \n             _  __/   _  / _  / / /_/ /  _  / / / /_/ /              \n             /_/      /_/  /_/ /_//___/  /_/ /_/____/               \n---------------------------------------------------------------------\nLoading  FinInG 1.5.4 (Finite Incidence Geometry) \nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Anton Betten (http://www.math.colostate.edu/~betten)\n   Philippe Cara (http://homepages.vub.ac.be/~pcara)\n   Jan De Beule (http://www.debeule.eu)\n   Michel Lavrauw (http://people.sabanciuniv.edu/~mlavrauw/)\n   Max Neunhoeffer (http://www-groups.mcs.st-and.ac.uk/~neunhoef/)\nFor help, type: ?FinInG \n---------------------------------------------------------------------\n",
-        "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
         "Date": "13/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -3886,7 +3798,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/FinInG"
         },
-        "Status": "accepted",
         "Subtitle": "Finite Incidence Geometry",
         "TestFile": "tst/testall.g",
         "Version": "1.5.4"
@@ -3952,19 +3863,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/float"
         },
-        "Status": "deposited",
         "Subtitle": "Integration of mpfr, mpfi, mpc, fplll and cxsc in GAP",
         "TestFile": "tst/testall.g",
         "Version": "1.0.3"
     },
     "format": {
         "AbstractHTML": "This package provides functions for computing with formations of finite solvable groups.",
-        "AcceptDate": "12/2000",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "49e13347e5f8cb292e6d1b7b2b399a162aeca6c388ab132750d5558536d61015",
         "ArchiveURL": "https://github.com/gap-packages/format/releases/download/v1.4.3/format-1.4.3",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Joachim Neub\u00fcser (Aachen)",
         "Date": "28/01/2020",
         "Dependencies": {
             "ExternalConditions": [],
@@ -4032,14 +3940,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/format"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with formations of finite solvable groups.",
         "TestFile": "tst/testall.g",
         "Version": "1.4.3"
     },
     "forms": {
         "AbstractHTML": "This package can be used for work with sesquilinear and quadratic forms on finite vector spaces; objects that are used to describe polar spaces and classical groups.",
-        "AcceptDate": "03/2009",
         "ArchiveFormats": ".tar.gz .zip .tar.bz2",
         "ArchiveSHA256": "0a6ba64420b61101e91d5fe9481b358f210ee96193364c81e83704ec73809b5f",
         "ArchiveURL": "https://github.com/gap-packages/forms/releases/download/v1.2.9/forms-1.2.9",
@@ -4050,7 +3956,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "---------------------------------------------------------------------\nLoading 'Forms' 1.2.9 (14/10/2022)\nby John Bamberg (http://school.maths.uwa.edu.au/~bamberg/)\n   Jan De Beule (http://www.debeule.eu)\nFor help, type: ?Forms \n---------------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (London)",
         "Date": "14/10/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -4121,19 +4026,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/forms"
         },
-        "Status": "accepted",
         "Subtitle": "Sesquilinear and Quadratic",
         "TestFile": "tst/testall.g",
         "Version": "1.2.9"
     },
     "fplsa": {
         "AbstractHTML": "The <span class=\"pkgname\">FPLSA</span> package uses    the authors' C program (version 4.0) that implements    a Lie Todd-Coxeter method for converting    finitely presented Lie algebras into isomorphic    structure constant algebras.    This is called via the GAP function IsomorphismSCTableAlgebra.",
-        "AcceptDate": "07/1999",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "a6fac07a4af350cae94907c22f5c74b7d02effa5aa565ff141a47d9170c9b39a",
         "ArchiveURL": "https://github.com/gap-packages/FPLSA/releases/download/v1.2.5/FPLSA-1.2.5",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Steve Linton (St Andrews)",
         "Date": "10/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -4195,7 +4097,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/FPLSA"
         },
-        "Status": "accepted",
         "Subtitle": "Finitely Presented Lie Algebras",
         "TestFile": "tst/testall.g",
         "Version": "1.2.5"
@@ -4215,7 +4116,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "Loading FR 2.4.12 ...\n",
-        "CommunicatedBy": "G\u00f6tz Pfeiffer (NUI Galway)",
         "Date": "03/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -4294,7 +4194,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/fr"
         },
-        "Status": "deposited",
         "Subtitle": "Computations with functionally recursive groups",
         "TestFile": "tst/testall.g",
         "Version": "2.4.12"
@@ -4369,7 +4268,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/Francy"
         },
-        "Status": "deposited",
         "Subtitle": "Framework for Interactive Discrete Mathematics",
         "TestFile": "tst/testall.g",
         "Version": "1.2.5"
@@ -4465,19 +4363,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/fwtree"
         },
-        "Status": "deposited",
         "Subtitle": "Computing trees related to some pro-p-groups of finite width",
         "TestFile": "tst/testall.g",
         "Version": "1.3"
     },
     "gapdoc": {
         "AbstractHTML": "This package contains a definition of a structure for <span class='pkgname'>GAP</span> (package) documentation, based on XML. It also contains  conversion programs for producing text-, PDF- or HTML-versions of such documents, with hyperlinks if possible.",
-        "AcceptDate": "10/2006",
         "ArchiveFormats": ".tar.bz2 .tar.gz -win.zip",
         "ArchiveSHA256": "59cf2a880a51984f238aa04fb1a1bcdbdd78c55901d83dd4b33a2c5c0328794c",
         "ArchiveURL": "http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.6",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Steve Linton (St Andrews)",
         "Date": "01/07/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -4558,7 +4453,6 @@
             "Type": "git",
             "URL": "https://github.com/frankluebeck/GAPDoc"
         },
-        "Status": "accepted",
         "Subtitle": "A Meta Package for GAP Documentation",
         "TestFile": "tst/test.tst",
         "Version": "1.6.6"
@@ -4651,7 +4545,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "Extended Gauss functionality for GAP",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
@@ -4741,14 +4634,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "Gauss functionality for the homalg project",
         "TestFile": "tst/testall.g",
         "Version": "2022.08-03"
     },
     "gbnp": {
         "AbstractHTML": "The <span class=\"pkgname\">GBNP</span> package provides algorithms for    computing Grobner bases of noncommutative polynomials with coefficients    from a field implemented in <span class=\"pkgname\">GAP</span> and with    respect to the \"total degree first then lexicographical\" ordering.    Further provided are some variations, such as a weighted and truncated    version and a tracing facility. The word \"algorithm\" is to be    interpreted loosely here: in general one cannot expect such an algorithm    to terminate, as it would imply solvability of the word problem for    finitely presented (semi)groups.",
-        "AcceptDate": "05/2010",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "3dfdc1a2c4fa3a80d704cfeb22398640fecf777760a750aa94f69e7fbcffaa51",
         "ArchiveURL": "https://github.com/gap-packages/gbnp/releases/download/v1.0.5/gbnp-1.0.5",
@@ -4764,7 +4655,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Alexander Hulpke (Fort Collins, CO)",
         "Date": "09/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -4832,7 +4722,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/gbnp"
         },
-        "Status": "accepted",
         "Subtitle": "computing Gr\u00f6bner bases of noncommutative polynomials",
         "TestFile": "tst/testall.g",
         "Version": "1.0.5"
@@ -4910,7 +4799,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/CAP_project"
         },
-        "Status": "deposited",
         "Subtitle": "Implementations of generalized morphisms for the CAP project",
         "TestFile": "tst/testall.g",
         "Version": "2022.12-01"
@@ -5008,7 +4896,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/genss"
         },
-        "Status": "deposited",
         "Subtitle": "Generic Schreier-Sims",
         "TestFile": "tst/testall.g",
         "Version": "1.6.8"
@@ -5162,7 +5049,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings",
         "TestFile": "tst/testall.g",
         "Version": "2022.09-02"
@@ -5309,14 +5195,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "Endow Commutative Rings with an Abelian Grading",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
     },
     "grape": {
         "AbstractHTML": "<span class=\"pkgname\">GRAPE</span> is a package for computing with graphs and groups, and is primarily designed for constructing and analysing graphs related to groups, finite geometries, and designs.",
-        "AcceptDate": "07/1993",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "78d7739c7b84702f93b71bda9b38ce704e5ea37040550541a6f615c542c7ae2f",
         "ArchiveURL": "https://github.com/gap-packages/grape/releases/download/v4.9.0/grape-4.9.0",
@@ -5326,7 +5210,6 @@
             "doc/manual.pdf",
             "nauty2_8_6/nug28.pdf"
         ],
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "09/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -5376,14 +5259,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/grape"
         },
-        "Status": "accepted",
         "Subtitle": "GRaph Algorithms using PErmutation groups",
         "TestFile": "tst/testall.g",
         "Version": "4.9.0"
     },
     "groupoids": {
         "AbstractHTML": "The groupoids package provides a collection of functions for computing with finite groupoids, graph of groups, and graphs of groupoids. These are based on the more basic structures of magmas with objects and their mappings. It provides functions for normal forms of elements in Free Products with Amalgamation and in HNN extensions. Up until April 2017 this package was named Gpd.",
-        "AcceptDate": "05/2015",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "8b0e54a55ffaa80c432bb14e3f5c6638b71e92a549d535cd8c4749c5bc2b2c84",
         "ArchiveURL": "https://github.com/gap-packages/groupoids/releases/download/v1.71/groupoids-1.71",
@@ -5397,7 +5278,6 @@
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading groupoids 1.71 (algorithms for finite groupoids)\nby Emma Moore and Chris Wensley (https://github.com/cdwensley)\n--------------------------------------------------------------\n",
-        "CommunicatedBy": "Derek Holt (Warwick)",
         "Date": "07/08/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -5478,7 +5358,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/groupoids"
         },
-        "Status": "accepted",
         "Subtitle": "Calculations with finite groupoids and their homomorphisms",
         "SupportEmail": "c.d.wensley@bangor.ac.uk",
         "TestFile": "tst/testall.g",
@@ -5486,12 +5365,10 @@
     },
     "grpconst": {
         "AbstractHTML": "The <span class=\"pkgname\">GrpConst</span> package contains methods to construct up to isomorphism the groups of a given order. The FrattiniExtensionMethod constructs all soluble groups of a given order. On request it gives only those that are (or are not) nilpotent or supersolvable or that do (or do not) have normal Sylow subgroups for some given set of primes. The CyclicSplitExtensionMethod constructs all groups having a normal Sylow subgroup for orders of the type p^n *q. The method relies on the availability of a list of all groups of order p^n. The UpwardsExtensions algorithm takes as input a permutation group G and a positive integer s and returns a list of permutation groups, one for each extension of G by a soluble group of order a divisor of s. This method can used to construct the non-solvable groups of a given order by taking the perfect groups of certain orders as input for G. The programs in this package have been used to construct a large part of the Small Groups library.",
-        "AcceptDate": "07/1999",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "5116367669dd022d2f288217ed5d491cfe392e5b55c3decc929372211374ca28",
         "ArchiveURL": "https://github.com/gap-packages/grpconst/releases/download/v2.6.3/grpconst-2.6.3",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Charles Wright (Eugene)",
         "Date": "14/11/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -5570,7 +5447,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/grpconst"
         },
-        "Status": "accepted",
         "Subtitle": "Constructing the Groups of a Given Order",
         "TestFile": "tst/testall.g",
         "Version": "2.6.3"
@@ -5672,20 +5548,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/guarana"
         },
-        "Status": "deposited",
         "Subtitle": "Applications of Lie methods for computations with infinite polycyclic groups",
         "TestFile": "tst/testall.g",
         "Version": "0.96.3"
     },
     "guava": {
         "AbstractHTML": "<span class=\"pkgname\">GUAVA</span> is a <span class=\"pkgname\">GAP</span> package for computing with codes. <span class=\"pkgname\">GUAVA</span> can construct unrestricted (non-linear), linear and cyclic codes; transform one code into another (for example by puncturing); construct a new code from two other codes (using direct sums for example); perform decoding/error-correction; and can calculate important data of codes (such as the minumim distance or covering radius) quickly. Limited ability to compute algebraic geometric codes.",
-        "AcceptDate": "02/2003",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "4f5b2495ac44684bc6318d52ed25e934aff05a14a8e24add242e167c461624a8",
         "ArchiveURL": "https://github.com/gap-packages/guava/releases/download/v3.17/guava-3.17",
         "AvailabilityTest": null,
         "BannerString": "\n   ____                             |\n  /                \\          /   --+--  Version 3.17\n /       |     | |\\ \\        / /|   |\n|    __  |     | | \\ \\      / / |          the GUAVA Group\n|      | |     | |--\\ \\    / /--|\n \\     | |     | |   \\ \\  / /   |\n  \\___/   \\___/  |    \\ \\/ /    |\n\n Homepage: https://gap-packages.github.io/guava\n Report issues at https://github.com/gap-packages/guava/issues\n",
-        "CommunicatedBy": "Charles Wright (Eugene)",
         "Date": "05/09/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -5835,20 +5708,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/guava"
         },
-        "Status": "accepted",
         "Subtitle": "a GAP package for computing with error-correcting codes",
         "TestFile": "tst/guava.tst",
         "Version": "3.17"
     },
     "hap": {
         "AbstractHTML": "This package provides some functions for group cohomology and algebraic topology. ",
-        "AcceptDate": "03/2006",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "dc5aaaaa4b0c793a8192db2cc7182b044301d26ccb3abf619d31fd95b038cd68",
         "ArchiveURL": "https://github.com/gap-packages/hap/releases/download/v1.47/hap-1.47",
         "AvailabilityTest": null,
         "BannerString": "Loading HAP 1.47 ...\n",
-        "CommunicatedBy": "Derek Holt (Warwick)",
         "Date": "14/08/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -5989,7 +5859,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/hap"
         },
-        "Status": "accepted",
         "Subtitle": "Homological Algebra Programming",
         "TestFile": "tst/testquick.g",
         "Version": "1.47"
@@ -6106,7 +5975,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/hapcryst"
         },
-        "Status": "deposited",
         "Subtitle": "A HAP extension for crystallographic groups",
         "TestFile": "tst/testall.g",
         "Version": "0.1.15"
@@ -6179,7 +6047,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/hecke"
         },
-        "Status": "deposited",
         "Subtitle": "Calculating decomposition matrices of Hecke algebras",
         "TestFile": "tst/testall.g",
         "Version": "1.5.3"
@@ -6284,7 +6151,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/HeLP"
         },
-        "Status": "deposited",
         "Subtitle": "Hertweck-Luthar-Passi method.",
         "TestFile": "tst/testall.g",
         "Version": "3.5"
@@ -6383,7 +6249,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "A homological algebra meta-package for computable Abelian categories",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
@@ -6532,14 +6397,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "A window to the outer world",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-02"
     },
     "idrel": {
         "AbstractHTML": "IdRel is a package for computing the identities among relations of a group presentation using rewriting, logged rewriting, monoid polynomials, module polynomials and Y-sequences.",
-        "AcceptDate": "05/2015",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "47a2590a72fb83b00dae7118dbff3bcd2e0786a7c31c8863b84954400197eea2",
         "ArchiveURL": "https://github.com/gap-packages/idrel/releases/download/v2.44/idrel-2.44",
@@ -6553,7 +6416,6 @@
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading IdRel 2.44 (Identities among Relations)\nby Anne Heyworth and Chris Wensley (https://github.com/cdwensley)\n-----------------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "04/06/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -6619,7 +6481,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/idrel"
         },
-        "Status": "accepted",
         "Subtitle": "Identities among relations",
         "TestFile": "tst/testall.g",
         "Version": "2.44"
@@ -6717,7 +6578,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/images"
         },
-        "Status": "deposited",
         "Subtitle": "Minimal and Canonical images",
         "TestFile": "tst/testall.g",
         "Version": "1.3.1"
@@ -6789,7 +6649,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/intpic"
         },
-        "Status": "deposited",
         "Subtitle": "A package for drawing integers",
         "TestFile": "tst/testall.g",
         "Version": "0.3.0"
@@ -6871,7 +6730,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/io"
         },
-        "Status": "deposited",
         "Subtitle": "Bindings for low level C library I/O routines",
         "TestFile": "tst/testall.g",
         "Version": "4.8.0"
@@ -6992,20 +6850,17 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "IO capabilities for the homalg project",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
     },
     "irredsol": {
         "AbstractHTML": "The <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">IRREDSOL</span> provides a library of all irreducible soluble subgroups of <i>GL(n,q)</i>, up to conjugacy, for <i>q<sup>n</sup></i> up to 2^24-1, and a library of the primitive soluble groups of degree up to 2^24-1.",
-        "AcceptDate": "08/2006",
         "ArchiveFormats": ".tar.bz2",
         "ArchiveSHA256": "2e1f79f5da5b268f6ffd64f67ff60c1292653535672ce51b91c057cd781bbe98",
         "ArchiveURL": "https://github.com/bh11/irredsol/releases/download/IRREDSOL-1.4.4/irredsol-1.4.4",
         "AvailabilityTest": null,
         "BannerString": "----------------------------------------------------------------------\n                          IRREDSOL Version 1.4.4\n  A library of irreducible soluble linear groups over finite fields\n                and of finite primivite soluble groups\n                         by Burkhard H\u00f6fling\n----------------------------------------------------------------------\n",
-        "CommunicatedBy": "Gerhard Hiss (Aachen)",
         "Date": "16/11/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -7066,7 +6921,6 @@
             "Type": "git",
             "URL": "https://github.com/bh11/irredsol.git"
         },
-        "Status": "accepted",
         "Subtitle": "A library of irreducible soluble linear groups over finite fields and of finite primivite soluble groups",
         "TestFile": "tst/testall.g",
         "TextBinaryFilesPatterns": [
@@ -7077,14 +6931,12 @@
     },
     "itc": {
         "AbstractHTML": "This <span class=\"pkgname\">GAP</span> package provides    access to interactive Todd-Coxeter computations    with finitely presented groups.",
-        "AcceptDate": "03/2000",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "19875fb3407fbda5f3696114d2a381fedacbfae6df311f928c49887ce8b18675",
         "ArchiveURL": "https://github.com/gap-packages/itc/releases/download/v1.5.1/itc-1.5.1",
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "\n          Loading  ITC 1.5.1  (Interactive Todd-Coxeter)\n            by V. Felsch, L. Hippe, and J. Neubueser\n              (Volkmar.Felsch@math.rwth-aachen.de)\n\n",
-        "CommunicatedBy": "Edmund F. Robertson (St Andrews)",
         "Date": "01/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -7161,7 +7013,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/itc"
         },
-        "Status": "accepted",
         "Subtitle": "Interactive Todd-Coxeter",
         "Version": "1.5.1"
     },
@@ -7219,7 +7070,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/json"
         },
-        "Status": "deposited",
         "Subtitle": "Reading and Writing JSON",
         "TestFile": "tst/testall.g",
         "Version": "2.1.1"
@@ -7372,7 +7222,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/JupyterKernel"
         },
-        "Status": "deposited",
         "Subtitle": "Jupyter kernel written in GAP",
         "TestFile": "tst/testinstall.g",
         "Version": "1.4.1"
@@ -7443,7 +7292,6 @@
             "Type": "git",
             "URL": "https://github.com/nathancarter/jupyterviz"
         },
-        "Status": "deposited",
         "Subtitle": "Visualization Tools for Jupyter and the GAP REPL",
         "SupportEmail": "ncarter@bentley.edu",
         "TestFile": "tst/testall.g",
@@ -7451,7 +7299,6 @@
     },
     "kan": {
         "AbstractHTML": "The Kan package provides functions for the computation of normal forms   of representatives of double cosets of finitely presented groups.",
-        "AcceptDate": "05/2015",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "f0e6fb53a4b5e6a6e698213a875ff43d53fae0c4f1a0efc8daacc5e975067e86",
         "ArchiveURL": "https://github.com/gap-packages/kan/releases/download/v1.34/kan-1.34",
@@ -7465,7 +7312,6 @@
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading Kan 1.34 (computing with Kan extensions)\nby Anne Heyworth and Chris Wensley (https://github.com/cdwensley)\n-----------------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "13/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -7534,14 +7380,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/kan"
         },
-        "Status": "accepted",
         "Subtitle": "including double coset rewriting systems",
         "TestFile": "tst/testall.g",
         "Version": "1.34"
     },
     "kbmag": {
         "AbstractHTML": "The <span class=\"pkgname\">kbmag</span> package is a       <span class=\"pkgname\">GAP</span> interface to some `C' programs   for running the Knuth-Bendix completion program on finite semigroup,   monoid or group presentations, and for attempting to compute automatic   structures of finitely presented groups",
-        "AcceptDate": "07/2003",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "99e32540a97a65c1577e8a3b0ef19e067b464b2517df3a78311a2a7fffd9f9e6",
         "ArchiveURL": "https://github.com/gap-packages/kbmag/releases/download/v1.5.10/kbmag-1.5.10",
@@ -7554,7 +7398,6 @@
         },
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "Charles Wright (Oregon)",
         "Date": "23/09/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -7610,19 +7453,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/kbmag"
         },
-        "Status": "accepted",
         "Subtitle": "Knuth-Bendix on Monoids and Automatic Groups",
         "TestFile": "tst/testall.g",
         "Version": "1.5.10"
     },
     "laguna": {
         "AbstractHTML": "The <span class=\"pkgname\">LAGUNA</span> package replaces the <span class=\"pkgname\">LAG</span> package and provides functionality for calculation of the normalized unit group of the modular group algebra of the finite p-group and for investigation of Lie algebra associated with group algebras and other associative algebras.",
-        "AcceptDate": "06/2003",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "bba2a2354c548685e0085a385d6027927add32014c28ca5e3127539b68cd87bf",
         "ArchiveURL": "https://github.com/gap-packages/laguna/releases/download/v3.9.5/laguna-3.9.5",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Herbert Pahlings (Aachen)",
         "Date": "27/04/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -7709,14 +7549,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/laguna"
         },
-        "Status": "accepted",
         "Subtitle": "Lie AlGebras and UNits of group Algebras",
         "TestFile": "tst/testall.g",
         "Version": "3.9.5"
     },
     "liealgdb": {
         "AbstractHTML": "",
-        "AcceptDate": "09/2007",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "378ee7dc82fde2e2e7fccf60bf6a92eb3fcefa9a05057f9404f7cc551968c427",
         "ArchiveURL": "https://github.com/gap-packages/liealgdb/releases/download/v2.2.1/liealgdb-2.2.1",
@@ -7728,7 +7566,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Bettina Eick (Braunschweig)",
         "Date": "07/10/2019",
         "Dependencies": {
             "ExternalConditions": [],
@@ -7804,20 +7641,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/liealgdb"
         },
-        "Status": "accepted",
         "Subtitle": "A database of Lie algebras",
         "TestFile": "tst/testall.g",
         "Version": "2.2.1"
     },
     "liepring": {
         "AbstractHTML": "",
-        "AcceptDate": "09/2014",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "7db4e49e8c619f93d5fc784301a5e1a7ed1a6e607e44ab58248ca0d00d2fc304",
         "ArchiveURL": "https://github.com/gap-packages/liepring/releases/download/v2.8/liepring-2.8",
         "AvailabilityTest": null,
         "BannerString": "----------------------------------------------------------------\nLoading  LiePRing 2.8\nby Bettina Eick and Michael Vaughan-Lee \n----------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (London)",
         "Date": "21/10/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -7882,14 +7716,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/liepring"
         },
-        "Status": "accepted",
         "Subtitle": "Database and algorithms for Lie p-rings",
         "TestFile": "tst/testall.g",
         "Version": "2.8"
     },
     "liering": {
         "AbstractHTML": "The package <span class=\"pkgname\">LieRing</span> contains                  functionality for working with finitely presented Lie rings and the Lazard correspondence.",
-        "AcceptDate": "12/2013",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "ae9fa477e5df51e4da024b96ac16a6f17c3b8715aa953dabb9a4004da782820f",
         "ArchiveURL": "https://github.com/gap-packages/liering/releases/download/v2.4.2/liering-2.4.2",
@@ -7902,7 +7734,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "LieRing\n a package for working with Lie rings \n by Serena Cical\u00f2 and Willem de Graaf\n",
-        "CommunicatedBy": "Max Neunhoeffer (Cologne)",
         "Date": "10/02/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -7967,7 +7798,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/liering"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with finitely presented Lie rings",
         "TestFile": "tst/testall.g",
         "Version": "2.4.2"
@@ -8058,7 +7888,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/CAP_project"
         },
-        "Status": "deposited",
         "Subtitle": "Category of Matrices over a Field for CAP",
         "TestFile": "tst/testall.g",
         "Version": "2022.12-04"
@@ -8163,14 +7992,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "A Package for Localization of Polynomial Rings",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
     },
     "loops": {
         "AbstractHTML": "The LOOPS package provides researchers in nonassociative algebra with a computational tool that integrates standard notions of loop theory with libraries of loops and group-theoretical algorithms of GAP. The package also expands GAP toward nonassociative structures.",
-        "AcceptDate": "05/2015",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "494efed928bfa46d85944f08216cbd01a67e40dd82207a7b36cda1edb3fcf4cc",
         "ArchiveURL": "https://github.com/gap-packages/loops/releases/download/v3.4.3/loops-3.4.3",
@@ -8183,7 +8010,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "14/11/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -8254,21 +8080,18 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/loops"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with quasigroups and loops in GAP",
         "TestFile": "tst/testall.g",
         "Version": "3.4.3"
     },
     "lpres": {
         "AbstractHTML": "The LPRES Package defines new GAP objects to work with L-presented groups, namely groups given by a finite generating set and a possibly-infinite set of relations given as iterates of finitely many seed relations by a finite set of endomorphisms. The package implements nilpotent quotient, Todd-Coxeter and Reidemeister-Schreier algorithms for L-presented groups.",
-        "AcceptDate": "09/2018",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "11b6644650459cccbe45ebcd791c5e8c713843604ae0b622a19a17b8d486b5c2",
         "ArchiveURL": "https://github.com/gap-packages/lpres/releases/download/v1.0.3/lpres-1.0.3",
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading lpres 1.0.3 ...\n",
-        "CommunicatedBy": "Alexander Konovalov (St Andrews)",
         "Date": "20/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -8358,7 +8181,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/lpres"
         },
-        "Status": "accepted",
         "Subtitle": "Nilpotent Quotients of L-Presented Groups",
         "TestFile": "tst/testall.g",
         "Version": "1.0.3"
@@ -8458,19 +8280,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/MajoranaAlgebras"
         },
-        "Status": "deposited",
         "Subtitle": "A package for constructing Majorana algebras and representations",
         "TestFile": "tst/testall.g",
         "Version": "1.5.1"
     },
     "mapclass": {
         "AbstractHTML": "The <span class=\"pkgname\">MapClass</span> package calculates the    mapping class group orbits for a given finite group.",
-        "AcceptDate": "11/2011",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "ec8cffca7e543662c522f0f6412cf994dc5fbe439d333f5f11e22923655b9c4e",
         "ArchiveURL": "https://github.com/gap-packages/MapClass/releases/download/v1.4.6/MapClass-1.4.6",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "17/09/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -8537,7 +8356,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/MapClass"
         },
-        "Status": "accepted",
         "Subtitle": "A Package For Mapping Class Orbit Computation",
         "TestFile": "tst/testall.g",
         "Version": "1.4.6"
@@ -8620,7 +8438,6 @@
             "Type": "git",
             "URL": "https://github.com/hulpke/matgrp/"
         },
-        "Status": "deposited",
         "Subtitle": "Matric Group Interface Routines",
         "TestFile": "tst/testall.g",
         "Version": "0.70"
@@ -8725,21 +8542,18 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "Matrices for the homalg project",
         "TestFile": "tst/testall.g",
         "Version": "2022.12-01"
     },
     "modisom": {
         "AbstractHTML": "The <span class=\"pkgname\">ModIsom</span> package contains various methods for computing with nilpotent associative algebras. In particular, it contains a method to determine the automorphism group and to test isomorphis of such algebras over finite fields and of modular group algebras of finite p-groups, and it contains a nilpotent quotient algorithm for finitely presented associative algebras and a method to determine Kurosh algebras.",
-        "AcceptDate": "11/2013",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "c002326f89ddbd5bc77d8aaca7fca1ca5b3947092c3961c1a04b2b24e2ee0446",
         "ArchiveURL": "https://github.com/gap-packages/modisom/releases/download/v2.5.3/modisom-2.5.3",
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading ModIsom 2.5.3... \n",
-        "CommunicatedBy": "Olexandr Konovalov (St Andrews)",
         "Date": "09/08/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -8809,7 +8623,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/modisom"
         },
-        "Status": "accepted",
         "Subtitle": "Computing automorphisms and checking isomorphisms for modular group algebras of finite p-groups",
         "TestFile": "tst/testall.g",
         "Version": "2.5.3"
@@ -8896,7 +8709,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/CAP_project"
         },
-        "Status": "deposited",
         "Subtitle": "Category R-pres for CAP",
         "TestFile": "tst/testall.g",
         "Version": "2022.12-01"
@@ -9038,7 +8850,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "A homalg based package for the Abelian category of finitely presented modules over computable rings",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
@@ -9141,7 +8952,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/CAP_project"
         },
-        "Status": "deposited",
         "Subtitle": "Monoidal and monoidal (co)closed categories",
         "TestFile": "tst/testall.g",
         "Version": "2022.12-01"
@@ -9240,21 +9050,18 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/NConvex"
         },
-        "Status": "deposited",
         "Subtitle": "A Gap package to perform polyhedral computations",
         "TestFile": "tst/testall.g",
         "Version": "2022.09-01"
     },
     "nilmat": {
         "AbstractHTML": "The <span class=\"pkgname\">Nilmat</span> package contains methods for checking whether a finitely generated matrix group over a finite field or the field of rational numbers is nilpotent, methods for computing with such nilpotent matrix groups and methods for constructing important classes of such nilpotent matrix groups.",
-        "AcceptDate": "08/2007",
         "ArchiveFormats": ".tar.gz .tar.bz2",
         "ArchiveSHA256": "4580fc05e4bcfc272165e7e4fd8b4266e8a38de2fce16523d976fd521c0f4404",
         "ArchiveURL": "https://github.com/gap-packages/nilmat/releases/download/v1.4.2/nilmat-1.4.2",
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading Nilmat 1.4.2...\n",
-        "CommunicatedBy": "Derek Holt (Warwick)",
         "Date": "05/08/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -9331,14 +9138,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/nilmat"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with nilpotent matrix groups",
         "TestFile": "tst/testall.g",
         "Version": "1.4.2"
     },
     "nock": {
         "AbstractHTML": "The <span class=\"pkgname\">NoCK</span> package    is used for computing Tolzanos's obstruction    for compact Clifford-Klein forms",
-        "AcceptDate": "07/2019",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "69023293e9abc695f15c2740df5902ba6e95d53bd3441b9c3fe25c410c207fc6",
         "ArchiveURL": "https://github.com/gap-packages/NoCK/releases/download/v1.5/NoCK-1.5",
@@ -9351,7 +9156,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "----------------------------------------------------------------\nNoCK Package 1.5\nby Maciej Boche\u0144ski, Piotr Jastrz\u0119bski, Anna Szczepkowska, Aleksy Tralle, Artur Woike.\n----------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "30/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -9457,7 +9261,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/NoCK"
         },
-        "Status": "accepted",
         "Subtitle": "Computing obstruction for the existence of compact Clifford-Klein form",
         "SupportEmail": "piojas@matman.uwm.edu.pl",
         "TestFile": "tst/testall.g",
@@ -9532,14 +9335,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/NormalizInterface"
         },
-        "Status": "deposited",
         "Subtitle": "GAP wrapper for Normaliz",
         "TestFile": "tst/testall.g",
         "Version": "1.3.5"
     },
     "nq": {
         "AbstractHTML": "This package provides access to the ANU nilpotent quotient program for computing nilpotent factor groups of finitely presented groups.",
-        "AcceptDate": "01/2003",
         "ArchiveFormats": ".tar.gz .tar.bz2",
         "ArchiveSHA256": "0db49d81173dccd36fb80525fd61fac6213a3843837ae0eac9867161e26ebad8",
         "ArchiveURL": "https://github.com/gap-packages/nq/releases/download/v2.5.9/nq-2.5.9",
@@ -9551,7 +9352,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "Loading nq 2.5.9 (Nilpotent Quotient Algorithm)\n  by Werner Nickel\n  maintained by Max Horn (horn@mathematik.uni-kl.de)\n",
-        "CommunicatedBy": "Joachim Neub\u00fcser (RWTH Aachen)",
         "Date": "26/10/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -9623,20 +9423,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/nq"
         },
-        "Status": "accepted",
         "Subtitle": "Nilpotent Quotients of Finitely Presented Groups",
         "TestFile": "tst/testall.g",
         "Version": "2.5.9"
     },
     "numericalsgps": {
         "AbstractHTML": "The <span class=\"pkgname\">NumericalSgps</span> package, is a package to compute with numerical semigroups.",
-        "AcceptDate": "05/2015",
         "ArchiveFormats": ".tar.gz .zip",
         "ArchiveSHA256": "7fa1966f3b5b50638eaf952a48667fd1ce09034d9e5d042c3f78f6d8d3c01e10",
         "ArchiveURL": "https://github.com/gap-packages/numericalsgps/releases/download/v1.3.1/NumericalSgps-1.3.1",
         "AvailabilityTest": null,
         "BannerString": "----------------------------------------------------------------\nLoading  NumericalSgps 1.3.1\nFor help, type: ?NumericalSgps: \nTo gain profit from other packages, please refer to chapter\n'External Packages' in the manual, or type: ?NumSgpsUse \n----------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "27/07/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -9821,20 +9618,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/numericalsgps"
         },
-        "Status": "accepted",
         "Subtitle": "A package for numerical semigroups",
         "TestFile": "tst/testall.g",
         "Version": "1.3.1"
     },
     "openmath": {
         "AbstractHTML": "This package provides an <a href=\"http://www.openmath.org/\">OpenMath</a> phrasebook for <span class=\"pkgname\">GAP</span>. This package allows <span class=\"pkgname\">GAP</span> users to import and export mathematical objects encoded in OpenMath, for the purpose of exchanging them with other applications that are OpenMath enabled.",
-        "AcceptDate": "08/2010",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "bb13f5fe0440c40d563fd82374a29b5f52df6babe7bd88d17dd37295a1544007",
         "ArchiveURL": "https://github.com/gap-packages/openmath/releases/download/v11.5.2/OpenMath-11.5.2",
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "David Joyner (Annapolis)",
         "Date": "06/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -9916,7 +9710,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/openmath"
         },
-        "Status": "accepted",
         "Subtitle": "OpenMath functionality in GAP",
         "TestFile": "tst/testall.g",
         "Version": "11.5.2"
@@ -10017,7 +9810,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/orb"
         },
-        "Status": "deposited",
         "Subtitle": "Methods to enumerate orbits",
         "TestFile": "tst/testall.g",
         "Version": "4.9.0"
@@ -10080,7 +9872,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/PackageManager"
         },
-        "Status": "deposited",
         "Subtitle": "Easily download and install GAP packages",
         "TestFile": "tst/test-without-texlive.g",
         "Version": "1.3.2"
@@ -10174,19 +9965,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/PatternClass"
         },
-        "Status": "deposited",
         "Subtitle": "A permutation pattern class package",
         "TestFile": "tst/testall.g",
         "Version": "2.4.3"
     },
     "permut": {
         "AbstractHTML": "This package provides functions for computing with permutability in finite groups.",
-        "AcceptDate": "04/2014",
         "ArchiveFormats": ".tar.gz .tar.bz2 .zip",
         "ArchiveSHA256": "568a27986066c2a389e6647b72c6987fd5fc4ff66aa3fdb99bf3d164e770273d",
         "ArchiveURL": "https://github.com/gap-packages/permut/releases/download/v2.0.4/permut-2.0.4",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Alice Niemeyer (Perth)",
         "Date": "27/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -10266,7 +10054,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/permut"
         },
-        "Status": "accepted",
         "Subtitle": "A package to deal with permutability in finite groups",
         "SupportEmail": "Ramon.Esteban@uv.es",
         "TestFile": "tst/testall.g",
@@ -10274,7 +10061,6 @@
     },
     "polenta": {
         "AbstractHTML": "The <span class=\"pkgname\">Polenta</span> package provides  methods to compute polycyclic presentations of matrix groups (finite or infinite). As a by-product, this package gives some functionality to compute certain module series for modules of solvable groups. For example, if G is a rational polycyclic matrix group, then we can compute the radical series of the natural Q[G]-module Q^d.",
-        "AcceptDate": "08/2005",
         "ArchiveFormats": ".tar.gz .tar.bz2",
         "ArchiveSHA256": "590092933940acaecdfaf2114a993696decca95cfc8eb324852dd4fc4abdebb8",
         "ArchiveURL": "https://github.com/gap-packages/polenta/releases/download/v1.3.10/polenta-1.3.10",
@@ -10286,7 +10072,6 @@
         },
         "Autoload": true,
         "AvailabilityTest": null,
-        "CommunicatedBy": "Charles Wright (Eugene)",
         "Date": "29/03/2022",
         "Dependencies": {
             "GAP": ">= 4.7",
@@ -10363,14 +10148,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/polenta"
         },
-        "Status": "accepted",
         "Subtitle": "Polycyclic presentations for matrix groups",
         "TestFile": "tst/testall.g",
         "Version": "1.3.10"
     },
     "polycyclic": {
         "AbstractHTML": "This package provides various algorithms for computations with polycyclic groups defined by polycyclic presentations.",
-        "AcceptDate": "01/2004",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "6983a72c90d92d0e6a3706dde7686c4a5658e48b04b5889d24808939896df007",
         "ArchiveURL": "https://github.com/gap-packages/polycyclic/releases/download/v2.16/polycyclic-2.16",
@@ -10381,7 +10164,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Charles Wright (Eugene)",
         "Date": "25/07/2020",
         "Dependencies": {
             "ExternalConditions": [],
@@ -10482,7 +10264,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/polycyclic"
         },
-        "Status": "accepted",
         "Subtitle": "Computation with polycyclic groups",
         "TestFile": "tst/testall.g",
         "Version": "2.16"
@@ -10559,7 +10340,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/polymaking"
         },
-        "Status": "deposited",
         "Subtitle": "Interfacing the geometry software polymake",
         "TestFile": "tst/testall.g",
         "Version": "0.8.6"
@@ -10658,7 +10438,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/primgrp"
         },
-        "Status": "deposited",
         "Subtitle": "GAP Primitive Permutation Groups Library",
         "TestFile": "tst/testall.g",
         "Version": "3.4.3"
@@ -10721,7 +10500,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/profiling"
         },
-        "Status": "deposited",
         "Subtitle": "Line by line profiling and code coverage for GAP",
         "TestFile": "tst/testall.g",
         "Version": "2.5.1"
@@ -10796,14 +10574,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/qpa"
         },
-        "Status": "deposited",
         "Subtitle": "Quivers and Path Algebras",
         "TestFile": "tst/testall.g",
         "Version": "1.34"
     },
     "quagroup": {
         "AbstractHTML": "The package <span class=\"pkgname\">QuaGroup</span> contains                  functionality for working with quantized enveloping algebras                 of finite-dimensional semisimple Lie algebras.",
-        "AcceptDate": "10/2003",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "b0ae5089e42d19be4c15e7422d3d4c94c0e79c533511a67b50ddc33630b12b56",
         "ArchiveURL": "https://github.com/gap-packages/quagroup/releases/download/v1.8.3/quagroup-1.8.3",
@@ -10815,7 +10591,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "     |                                                                 \n     |          QuaGroup 1.8.3\n     |                                                                 \n-----------     A package for dealing with quantized enveloping algebras\n     |                                                                 \n     |          Willem de Graaf                                        \n     |          degraaf@science.unitn.it                               \n\n",
-        "CommunicatedBy": "Gerhard Hiss (Aachen)",
         "Date": "10/02/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -10869,20 +10644,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/quagroup"
         },
-        "Status": "accepted",
         "Subtitle": "Computations with quantum groups",
         "TestFile": "tst/testall.g",
         "Version": "1.8.3"
     },
     "radiroot": {
         "AbstractHTML": "The <span class=\"pkgname\">RadiRoot</span> package installs a method to    display the roots of a rational polynomial as radicals if it is solvable.",
-        "AcceptDate": "02/2007",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "9a14209632490ab1149022165c2936f57cb7044293ffb2aef0580b3d4085eb8a",
         "ArchiveURL": "https://github.com/gap-packages/radiroot/releases/download/v2.9/radiroot-2.9",
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "Edmund Robertson (St Andrews)",
         "Date": "01/03/2022",
         "Dependencies": {
             "ExternalConditions": [
@@ -10942,14 +10714,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/radiroot"
         },
-        "Status": "accepted",
         "Subtitle": "Roots of a Polynomial as Radicals",
         "TestFile": "tst/testall.g",
         "Version": "2.9"
     },
     "rcwa": {
         "AbstractHTML": "This package provides implementations of algorithms and methods for computation in certain infinite permutation groups.",
-        "AcceptDate": "04/2005",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "181e5b7e69f5267ede042a5d505217c01ceccc3d21baa96b2bc71341caf33728",
         "ArchiveURL": "https://github.com/gap-packages/rcwa/releases/download/v4.7.1/rcwa-4.7.1",
@@ -10962,7 +10732,6 @@
         },
         "AvailabilityTest": null,
         "BannerString": "\nLoading RCWA 4.7.1 ([R]esidue-[C]lass-[W]ise [A]ffine groups)\n  by Stefan Kohl, sk239@st-andrews.ac.uk.\nSee ?RCWA:About for information about the package.\n\n",
-        "CommunicatedBy": "Bettina Eick (Braunschweig)",
         "Date": "06/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -11038,19 +10807,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/rcwa"
         },
-        "Status": "accepted",
         "Subtitle": "Residue-Class-Wise Affine Groups",
         "TestFile": "tst/testall.g",
         "Version": "4.7.1"
     },
     "rds": {
         "AbstractHTML": "This package provides functions for the complete enumeration of relative difference sets.",
-        "AcceptDate": "02/2008",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "d58c1320b84fde09d3b778f64de3ce312e9ee53f3aa4361ff846d8ffa4a34faa",
         "ArchiveURL": "https://github.com/gap-packages/rds/releases/download/v1.8/rds-1.8",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Leonard Soicher (Queen Mary, London)",
         "Date": "21/02/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -11115,7 +10881,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/rds"
         },
-        "Status": "accepted",
         "Subtitle": "A package for searching relative difference sets",
         "TestFile": "tst/testall.g",
         "Version": "1.8"
@@ -11372,7 +11137,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/recog"
         },
-        "Status": "deposited",
         "Subtitle": "A package for constructive recognition of permutation and matrix groups",
         "TestFile": "tst/testquick.g",
         "Version": "1.4.2"
@@ -11453,14 +11217,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/RepnDecomp"
         },
-        "Status": "deposited",
         "Subtitle": "Decompose representations of finite groups into irreducibles",
         "TestFile": "tst/testall.g",
         "Version": "1.2.1"
     },
     "repsn": {
         "AbstractHTML": "The package provides <span class=\"pkgname\">GAP</span> functions for computing characteristic zero matrix representations of finite groups.",
-        "AcceptDate": "05/2004",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "ea2c3e3b4193ded61b95704cdd4bdfab30deb740810d0a23129e690037ecdd2e",
         "ArchiveURL": "https://github.com/gap-packages/repsn/releases/download/v3.1.0/repsn-3.1.0",
@@ -11470,7 +11232,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Charles Wright (Eugene)",
         "Date": "22/02/2019",
         "Dependencies": {
             "ExternalConditions": [],
@@ -11527,7 +11288,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/repsn"
         },
-        "Status": "accepted",
         "Subtitle": "Constructing representations of finite groups",
         "TestFile": "tst/testall.g",
         "Version": "3.1.0"
@@ -11609,7 +11369,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/resclasses"
         },
-        "Status": "deposited",
         "Subtitle": "Set-Theoretic Computations with Residue Classes",
         "TestFile": "tst/testall.g",
         "Version": "4.7.3"
@@ -11789,7 +11548,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "Dictionaries of external rings",
         "TestFile": "tst/testall.g",
         "Version": "2022.11-01"
@@ -11882,14 +11640,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "SCO - Simplicial Cohomology of Orbifolds",
         "TestFile": "tst/testall.g",
         "Version": "2022.09-01"
     },
     "scscp": {
         "AbstractHTML": "This package implements the <a href=\"https://www.openmath.org/standard/scscp/\">Symbolic Computation Software Composability Protocol</a> for the GAP system.",
-        "AcceptDate": "08/2010",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "c35a318f7350d6ddfb373214e845f1260edbf421f21bd4aa7625f603fc3b0633",
         "ArchiveURL": "https://github.com/gap-packages/scscp/releases/download/v2.4.0/SCSCP-2.4.0",
@@ -11898,7 +11654,6 @@
         "BinaryFiles": [
             "demo/maple2gap.mw"
         ],
-        "CommunicatedBy": "David Joyner (Annapolis)",
         "Date": "10/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -11974,7 +11729,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/scscp"
         },
-        "Status": "accepted",
         "Subtitle": "Symbolic Computation Software Composability Protocol in GAP",
         "TestFile": "tst/offline.tst",
         "Version": "2.4.0"
@@ -12356,20 +12110,17 @@
             "Type": "git",
             "URL": "https://github.com/semigroups/Semigroups"
         },
-        "Status": "deposited",
         "Subtitle": "A package for semigroups and monoids",
         "TestFile": "tst/teststandard.g",
         "Version": "5.2.0"
     },
     "sglppow": {
         "AbstractHTML": "",
-        "AcceptDate": "08/2016",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "15b2d346c94167984adf0ec8b7ac84ce2b6480227b5964e7108fb7afe369eb90",
         "ArchiveURL": "https://github.com/gap-packages/sglppow/releases/download/v2.3/sglppow-2.3",
         "AvailabilityTest": null,
         "BannerString": "----------------------------------------------------------------\nLoading SglPPow 2.3\nby Michael Vaughan-Lee and Bettina Eick \n----------------------------------------------------------------\n",
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "04/11/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -12436,7 +12187,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/sglppow"
         },
-        "Status": "accepted",
         "Subtitle": "Database of groups of prime-power order for some prime-powers",
         "TestFile": "tst/testall.g",
         "Version": "2.3"
@@ -12508,14 +12258,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/sgpviz"
         },
-        "Status": "deposited",
         "Subtitle": "A package for semigroup visualization",
         "TestFile": "tst/testall.g",
         "Version": "0.999.5"
     },
     "simpcomp": {
         "AbstractHTML": "<span class=\"pkgname\">simpcomp</span> is a <span class=\"pkgname\">GAP</span> package for working with simplicial complexes. It allows the computation of many properties of simplicial complexes (such as the f-, g- and h-vectors, the face lattice, the automorphism group, (co-)homology with explicit basis computation, intersection form, etc.) and provides the user with functions to compute new complexes from old (simplex links and stars, connected sums, cartesian products, handle additions, bistellar flips, etc.). Furthermore, it comes with an extensive library of known triangulations of manifolds and provides the user with the possibility to create own complex libraries.<br /> <span class=\"pkgname\">simpcomp</span> caches computed properties of a simplicial complex, thus avoiding unnecessary computations, internally handles the vertex labeling of the complexes and insures the consistency of a simplicial complex throughout all operations.<br /> <span class=\"pkgname\">simpcomp</span> relies on the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">homology</span> for its homology computation, but also provides the user with an own (co-)homology algorithm in case the packacke <span class=\"pkgname\">homology</span> is not available. For automorphism group computation the <span class=\"pkgname\">GAP</span> package <span class=\"pkgname\">GRAPE</span> is used, which in turn uses the program <tt>nauty</tt> by Brendan McKay. An internal automorphism group calculation algorithm in used as fallback if the <span class=\"pkgname\">GRAPE</span> package is not available.",
-        "AcceptDate": "11/2013",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "2a1a33068b038776d6932f13b5eb63d32b0799906a2ec190f585b2931d724dcd",
         "ArchiveURL": "https://github.com/simpcomp-team/simpcomp/releases/download/v2.1.14/simpcomp-2.1.14",
@@ -12530,7 +12278,6 @@
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading simpcomp 2.1.14\nby F. Effenberger and J. Spreer\nhttps://github.com/simpcomp-team/simpcomp\n",
-        "CommunicatedBy": "Graham Ellis (Galway)",
         "Date": "15/03/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -12631,7 +12378,6 @@
             "Type": "git",
             "URL": "https://github.com/simpcomp-team/simpcomp"
         },
-        "Status": "accepted",
         "Subtitle": "A GAP toolbox for simplicial complexes",
         "TestFile": "tst/simpcomp.tst",
         "Version": "2.1.14"
@@ -12709,7 +12455,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/singular"
         },
-        "Status": "deposited",
         "Subtitle": "A GAP interface to Singular",
         "TestFile": "tst/testall.g",
         "Version": "2022.09.23"
@@ -12793,14 +12538,12 @@
             "Type": "git",
             "URL": "https://github.com/snw-0/sl2-reps"
         },
-        "Status": "deposited",
         "Subtitle": "Constructing symmetric representations of SL(2,Z).",
         "TestFile": "tst/testall.g",
         "Version": "1.1"
     },
     "sla": {
         "AbstractHTML": "The package <span class=\"pkgname\">SLA</span> contains                  functionality for working with simple Lie algebras,",
-        "AcceptDate": "01/2016",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "debcc69d2815dce644d7150987d7c1059127f7db1c668167880d272caaea09d5",
         "ArchiveURL": "https://github.com/gap-packages/sla/releases/download/v1.5.3/sla-1.5.3",
@@ -12812,7 +12555,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Leonard Soicher (QMUL)",
         "Date": "15/11/2019",
         "Dependencies": {
             "ExternalConditions": [],
@@ -12872,19 +12614,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/sla"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with simple Lie algebras",
         "TestFile": "tst/testall.g",
         "Version": "1.5.3"
     },
     "smallgrp": {
         "AbstractHTML": "The <span class=\"smallgrp\">SmallGrp</span> package provides the library of groups of certain \"small\" orders. The groups are sorted by their orders and they are listed up to isomorphism; that is, for each of the available orders a complete and irredundant list of isomorphism type representatives of groups is given.",
-        "AcceptDate": "02/2002",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "4ffeab3c5f7b0f4fa6768d95e69b470c2c92e1ba197ac9515663082354541951",
         "ArchiveURL": "https://github.com/gap-packages/SmallGrp/releases/download/v1.5.1/SmallGrp-1.5.1",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Mike Newman (Canberra)",
         "Date": "04/11/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -12961,7 +12700,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/SmallGrp"
         },
-        "Status": "accepted",
         "Subtitle": "The GAP Small Groups Library",
         "TestFile": "tst/testall.g",
         "Version": "1.5.1"
@@ -13042,20 +12780,17 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/smallsemi"
         },
-        "Status": "deposited",
         "Subtitle": "A library of small semigroups",
         "TestFile": "tst/testall.g",
         "Version": "0.6.13"
     },
     "sonata": {
         "AbstractHTML": "The <span class=\"pkgname\">SONATA</span> package provides methods for     the construction and analysis of finite nearrings.",
-        "AcceptDate": "04/2003",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "0a44ef0b269766c69b59681ea3a640bc95e2ce17455a4e70088491b471f39cce",
         "ArchiveURL": "https://github.com/gap-packages/sonata/releases/download/v2.9.6/sonata-2.9.6",
         "AvailabilityTest": null,
         "BannerString": "\n  ___________________________________________________________________________\n /        ___\n||       /   \\                 /\\    Version 2.9.6\n||      ||   ||  |\\    |      /  \\               /\\       Erhard Aichinger\n \\___   ||   ||  |\\\\   |     /____\\_____________/__\\      Franz Binder\n     \\  ||   ||  | \\\\  |    /      \\     ||    /    \\     Juergen Ecker\n     ||  \\___/   |  \\\\ |   /        \\    ||   /      \\    Peter Mayr\n     ||          |   \\\\|  /          \\   ||               Christof Noebauer\n \\___/           |    \\|                 ||\n\n System    Of   Nearrings     And      Their Applications\n Info: https://gap-packages.github.io/sonata/\n\n",
-        "CommunicatedBy": "Charles R.B. Wright (Univ. of Oregon)",
         "Date": "06/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -13162,14 +12897,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/sonata"
         },
-        "Status": "accepted",
         "Subtitle": "System of nearrings and their applications",
         "TestFile": "tst/testall.g",
         "Version": "2.9.6"
     },
     "sophus": {
         "AbstractHTML": "",
-        "AcceptDate": "10/2004",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "cd7f173d7122b1e72a1f8ae3131e7685cd586dd362bd7efd21fe542fac5411c3",
         "ArchiveURL": "https://github.com/gap-packages/sophus/releases/download/v1.27/sophus-1.27",
@@ -13181,7 +12914,6 @@
             }
         },
         "AvailabilityTest": null,
-        "CommunicatedBy": "Olexandr Konovalov (Zaporizhzhia)",
         "Date": "09/08/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -13241,7 +12973,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/sophus"
         },
-        "Status": "accepted",
         "Subtitle": "Computing in nilpotent Lie algebras",
         "TestFile": "tst/testall.g",
         "Version": "1.27"
@@ -13323,7 +13054,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/spinsym"
         },
-        "Status": "deposited",
         "Subtitle": "Brauer tables of spin-symmetric groups",
         "TestFile": "tst/testall.tst",
         "Version": "1.5.2"
@@ -13390,19 +13120,16 @@
             "Type": "git",
             "URL": "https://github.com/frankluebeck/StandardFF"
         },
-        "Status": "dev",
         "Subtitle": "Standard finite fields and cyclic generators",
         "TestFile": "tst/testall.g",
         "Version": "0.9.4"
     },
     "symbcompcc": {
         "AbstractHTML": "The <span class=\"pkgname\">SymbCompCC</span> package computes with parametrised presentations for finite p-groups of fixed coclass.",
-        "AcceptDate": "11/2011",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "3d00760f1670acbc66219d7d72b9be62218e91b14716522d7c1922d6a50cf856",
         "ArchiveURL": "https://github.com/gap-packages/SymbCompCC/releases/download/v1.3.2/SymbCompCC-1.3.2",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Mike Newman (Canberra, Australia)",
         "Date": "10/02/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -13461,7 +13188,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/SymbCompCC"
         },
-        "Status": "accepted",
         "Subtitle": "Computing with parametrised presentations for p-groups of fixed coclass",
         "TestFile": "tst/testall.g",
         "Version": "1.3.2"
@@ -13545,7 +13271,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/Thelma"
         },
-        "Status": "deposited",
         "Subtitle": "THreshold ELements, Modeling and Applications",
         "TestFile": "tst/testall.g",
         "Version": "1.3"
@@ -13638,7 +13363,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/tomlib"
         },
-        "Status": "deposited",
         "Subtitle": "The GAP Library of Tables of Marks",
         "TestFile": "tst/testall.g",
         "Version": "1.2.9"
@@ -13715,14 +13439,12 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/homalg_project"
         },
-        "Status": "deposited",
         "Subtitle": "Special methods and knowledge propagation tools",
         "TestFile": "tst/testall.g",
         "Version": "2022.12-01"
     },
     "toric": {
         "AbstractHTML": "<span class=\"pkgname\">toric</span> is a <span class=\"pkgname\">GAP</span>package for computing with toric varieties.",
-        "AcceptDate": "10/2005",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "8eb65c64bc38038957e9552fc8f409023407a0ed079884fd484fffe8d61e03de",
         "ArchiveURL": "https://github.com/gap-packages/toric/releases/download/v1.9.5/Toric-1.9.5",
@@ -13734,7 +13456,6 @@
         },
         "Autoload": false,
         "AvailabilityTest": null,
-        "CommunicatedBy": "Gerhard Hiss (Aachen)",
         "Date": "07/10/2019",
         "Dependencies": {
             "ExternalConditions": [],
@@ -13792,7 +13513,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/toric"
         },
-        "Status": "accepted",
         "Subtitle": "toric varieties and some combinatorial geometry computations",
         "TestFile": "tst/testall.g",
         "Version": "1.9.5"
@@ -13906,7 +13626,6 @@
             "Type": "git",
             "URL": "https://github.com/homalg-project/ToricVarieties_project"
         },
-        "Status": "deposited",
         "Subtitle": "A package to handle toric varieties",
         "TestFile": "tst/testall.g",
         "Version": "2022.07.13"
@@ -13963,20 +13682,17 @@
             "Type": "git",
             "URL": "https://github.com/hulpke/transgrp"
         },
-        "Status": "deposited",
         "Subtitle": "Transitive Groups Library",
         "TestFile": "tst/testall.g",
         "Version": "3.6.3"
     },
     "ugaly": {
         "AbstractHTML": "<span class=\"pkgname\">UGALY</span> (Universal Groups Acting LocallY) is a <span class=\"pkgname\">GAP</span> package that provides methods to create, analyse and find local actions of generalised universal groups acting on locally finite regular trees, following Burger-Mozes and Tornier.",
-        "AcceptDate": "07/2021",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "741a65ca43fc81dff5d7c2181d47612006579dd67b54fb74aca30cb04bc5acd4",
         "ArchiveURL": "https://github.com/gap-packages/UGALY/releases/download/v4.0.3/UGALY-4.0.3",
         "AvailabilityTest": null,
         "BannerString": "\nVersion 4.0.3\n __  __     ______     ______     __         __  __    \n/\\ \\/\\ \\   /\\  ___\\   /\\  __ \\   /\\ \\       /\\ \\_\\ \\   \n\\ \\ \\_\\ \\  \\ \\ \\__ \\  \\ \\  __ \\  \\ \\ \\____  \\ \\____ \\  by Khalil Hannouch\n \\ \\_____\\  \\ \\_____\\  \\ \\_\\ \\_\\  \\ \\_____\\  \\/\\_____\\   and Stephan Tornier\n  \\/_____/   \\/_____/   \\/_/\\/_/   \\/_____/   \\/_____/ \n                                                       \n Universal      Groups      Acting        LocallY    \n",
-        "CommunicatedBy": "Laurent Bartholdi (G\u00f6ttingen)",
         "Date": "14/07/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -14044,7 +13760,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/UGALY"
         },
-        "Status": "accepted",
         "Subtitle": "Universal Groups Acting LocallY",
         "TestFile": "tst/testall.g",
         "Version": "4.0.3"
@@ -14113,19 +13828,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/unipot"
         },
-        "Status": "deposited",
         "Subtitle": "Computing with elements of unipotent subgroups of Chevalley groups",
         "TestFile": "tst/testall.g",
         "Version": "1.5"
     },
     "unitlib": {
         "AbstractHTML": "The <span class=\"pkgname\">UnitLib</span> package extends the <span class=\"pkgname\">LAGUNA</span> package and provides the library of normalized unit groups of modular group algebras of all finite p-groups of order less than 243 over the field of p elements.",
-        "AcceptDate": "03/2007",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "fbc3f89b1011c1d418dacb8a77f1fe15e1b2ae883c00c873a04e488a17af5ada",
         "ArchiveURL": "https://github.com/gap-packages/unitlib/releases/download/v4.1.0/unitlib-4.1.0",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Bettina Eick (Braunschweig)",
         "Date": "26/04/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -14201,7 +13913,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/unitlib"
         },
-        "Status": "accepted",
         "Subtitle": "Library of normalized unit groups of modular group algebras",
         "TestFile": "tst/testall.g",
         "Version": "4.1.0"
@@ -14330,7 +14041,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/utils"
         },
-        "Status": "deposited",
         "Subtitle": "Utility functions in GAP",
         "TestFile": "tst/testall.g",
         "Version": "0.81"
@@ -14400,7 +14110,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/uuid"
         },
-        "Status": "deposited",
         "Subtitle": "RFC 4122 UUIDs",
         "TestFile": "tst/testall.g",
         "Version": "0.7"
@@ -14482,19 +14191,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/walrus"
         },
-        "Status": "deposited",
         "Subtitle": "A new approach to proving hyperbolicity",
         "TestFile": "tst/testall.g",
         "Version": "0.9991"
     },
     "wedderga": {
         "AbstractHTML": "<span class=\"pkgname\">Wedderga</span> is the package to compute the simple components of the Wedderburn decomposition of semisimple group algebras of finite groups over finite fields and over subfields of finite cyclotomic extensions of the rationals. It also contains functions that produce the primitive central idempotents of semisimple group algebras and functions for computing Schur indices. Other functions of <span class=\"pkgname\">Wedderga</span> allow one to construct crossed products over a group with coefficients in an associative ring with identity and the multiplication determined by a given action and twisting.",
-        "AcceptDate": "01/2008",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "f47e4750eb4df8d0936262a27f512921081cfdbb2a8b0f58c7cbab3cde4ae6df",
         "ArchiveURL": "https://github.com/gap-packages/wedderga/releases/download/v4.10.2/wedderga-4.10.2",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Gerhard Hiss (Aachen)",
         "Date": "29/04/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -14642,19 +14348,16 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/wedderga"
         },
-        "Status": "accepted",
         "Subtitle": "Wedderburn Decomposition of Group Algebras",
         "TestFile": "tst/testall.g",
         "Version": "4.10.2"
     },
     "xgap": {
         "AbstractHTML": "The <span class=\"pkgname\">XGAP</span> package allows to use graphics in GAP.",
-        "AcceptDate": "07/1999",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "4c5157785d68b562a29d97c1e63ceaefd34e02500a3ff38f0ef90c94fd1ebfea",
         "ArchiveURL": "https://github.com/gap-packages/xgap/releases/download/v4.31/xgap-4.31",
         "AvailabilityTest": null,
-        "CommunicatedBy": "Gerhard Hi\u00df (Aachen)",
         "Date": "17/02/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -14717,14 +14420,12 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/xgap"
         },
-        "Status": "accepted",
         "Subtitle": "a graphical user interface for GAP",
         "TestFile": "tst/testall.g",
         "Version": "4.31"
     },
     "xmod": {
         "AbstractHTML": "The <span class=\"pkgname\">XMod</span> package provides a collection   of functions for computing with crossed modules and cat1-groups, their derivations and sections, morphisms of these structures, and higher-dimensional generalisations.",
-        "AcceptDate": "12/1996",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "502884be429e43ceb868481e1ca7bbbab3f1490474eb374e37939f5b1eb71c30",
         "ArchiveURL": "https://github.com/gap-packages/xmod/releases/download/v2.88/XMod-2.88",
@@ -14738,7 +14439,6 @@
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "Loading XMod 2.88 (methods for crossed modules and cat1-groups)\nby Chris Wensley (https://github.com/cdwensley),\n with contributions from:\n    Murat Alp (muratalp@nigde.edu.tr),\n    Alper Odabas (aodabas@ogu.edu.tr),\nand Enver Uslu.\n-----------------------------------------------------------------------------\n",
-        "CommunicatedBy": "Derek Holt (Warwick)",
         "Date": "28/04/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -14847,7 +14547,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/xmod"
         },
-        "Status": "accepted",
         "Subtitle": "Crossed Modules and Cat1-Groups",
         "SupportEmail": "c.d.wensley@bangor.ac.uk",
         "TestFile": "tst/testall.g",
@@ -14855,7 +14554,6 @@
     },
     "xmodalg": {
         "AbstractHTML": "The <span class=\"pkgname\">XModAlg</span> package provides a collection of functions for computing with crossed modules and cat1-algebras and morphisms of these structures.",
-        "AcceptDate": "",
         "ArchiveFormats": ".tar.gz",
         "ArchiveSHA256": "007ea97b88eade9fe0d5ccd59e61051aecd53bee44aa504a7d7ec84e6c5e75e9",
         "ArchiveURL": "https://github.com/gap-packages/xmodalg/releases/download/v1.23/XModAlg-1.23",
@@ -14869,7 +14567,6 @@
         "Autoload": false,
         "AvailabilityTest": null,
         "BannerString": "-----------------------------------------------------------------------------\nLoading XModAlg 1.23 (03/12/2022) for GAP 4.11 \nMethods for crossed modules of commutative algebras and cat1-algebras\nby Zekeriya Arvasi (zarvasi@ogu.edu.tr) and Alper Odabas (aodabas@ogu.edu.tr).\n-----------------------------------------------------------------------------\n",
-        "CommunicatedBy": "",
         "Date": "03/12/2022",
         "Dependencies": {
             "ExternalConditions": [],
@@ -14936,7 +14633,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/xmodalg"
         },
-        "Status": "deposited",
         "Subtitle": "Crossed Modules and Cat1-Algebras",
         "SupportEmail": "aodabas@ogu.edu.tr",
         "TestFile": "tst/testall.g",
@@ -15015,7 +14711,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/YangBaxter"
         },
-        "Status": "deposited",
         "Subtitle": "Combinatorial Solutions for the Yang-Baxter equation",
         "TestFile": "tst/testall.g",
         "Version": "0.10.2"
@@ -15103,7 +14798,6 @@
             "Type": "git",
             "URL": "https://github.com/gap-packages/ZeroMQInterface"
         },
-        "Status": "deposited",
         "Subtitle": "ZeroMQ bindings for GAP",
         "TestFile": "tst/testall.g",
         "Version": "0.14"

--- a/_data/package_status.yml
+++ b/_data/package_status.yml
@@ -1,0 +1,459 @@
+4ti2interface:
+  Status: deposited
+ace:
+  Status: accepted
+  AcceptDate: 04/2001
+  CommunicatedBy: Joachim Neubüser (Aachen)
+aclib:
+  Status: accepted
+  AcceptDate: 02/2001
+  CommunicatedBy: Gerhard Hiss (Aachen)
+agt:
+  Status: deposited
+alnuth:
+  Status: accepted
+  AcceptDate: 01/2004
+  CommunicatedBy: Charles Wright (Eugene)
+anupq:
+  Status: accepted
+  AcceptDate: 04/2002
+  CommunicatedBy: Charles Wright (Eugene)
+atlasrep:
+  Status: accepted
+  AcceptDate: 04/2001
+  CommunicatedBy: Herbert Pahlings (Aachen)
+autodoc:
+  Status: deposited
+automata:
+  Status: accepted
+  AcceptDate: 09/2004
+  CommunicatedBy: Edmund Robertson (St. Andrews)
+automgrp:
+  Status: accepted
+  AcceptDate: 03/2016
+  CommunicatedBy: Leonard Soicher (Queen Mary, London)
+autpgrp:
+  Status: accepted
+  AcceptDate: 09/2000
+  CommunicatedBy: Derek F. Holt (Warwick)
+browse:
+  Status: deposited
+cap:
+  Status: deposited
+caratinterface:
+  Status: accepted
+  AcceptDate: 02/2000
+  CommunicatedBy: Herbert Pahlings (Aachen)
+cddinterface:
+  Status: deposited
+circle:
+  Status: accepted
+  AcceptDate: 01/2008
+  CommunicatedBy: Leonard Soicher (QMUL)
+classicpres:
+  Status: deposited
+cohomolo:
+  Status: accepted
+  AcceptDate: 01/1970
+  CommunicatedBy: unknown (unknown)
+congruence:
+  Status: accepted
+  AcceptDate: 09/2014
+  CommunicatedBy: Graham Ellis (Galway)
+corelg:
+  Status: accepted
+  AcceptDate: 01/2014
+  CommunicatedBy: Bettina Eick (Braunschweig)
+crime:
+  Status: accepted
+  AcceptDate: 10/2006
+  CommunicatedBy: Bettina Eick (Braunschweig)
+crisp:
+  Status: accepted
+  AcceptDate: 12/2000
+  CommunicatedBy: Joachim Neubüser (Aachen)
+crypting:
+  Status: deposited
+cryst:
+  Status: accepted
+  AcceptDate: 02/2000
+  CommunicatedBy: Herbert Pahlings (Aachen)
+crystcat:
+  Status: accepted
+  AcceptDate: 02/2000
+  CommunicatedBy: Herbert Pahlings (Aachen)
+ctbllib:
+  Status: deposited
+cubefree:
+  Status: accepted
+  AcceptDate: 10/2007
+  CommunicatedBy: David Joyner (Annapolis)
+curlinterface:
+  Status: deposited
+cvec:
+  Status: deposited
+datastructures:
+  Status: deposited
+deepthought:
+  Status: deposited
+design:
+  Status: accepted
+  AcceptDate: 08/2006
+  CommunicatedBy: Akos Seress (Ohio State)
+difsets:
+  Status: accepted
+  AcceptDate: 07/2019
+  CommunicatedBy: Alexander Hulpke (Colorado State)
+digraphs:
+  Status: deposited
+edim:
+  Status: accepted
+  AcceptDate: 08/1999
+  CommunicatedBy: Mike Atkinson (St Andrews)
+example:
+  Status: deposited
+examplesforhomalg:
+  Status: deposited
+factint:
+  Status: accepted
+  AcceptDate: 07/1999
+  CommunicatedBy: Mike Atkinson (St. Andrews)
+ferret:
+  Status: deposited
+fga:
+  Status: accepted
+  AcceptDate: 05/2005
+  CommunicatedBy: Edmund Robertson (St. Andrews)
+fining:
+  Status: accepted
+  AcceptDate: 11/2017
+  CommunicatedBy: Olexandr Konovalov (St Andrews)
+float:
+  Status: deposited
+format:
+  Status: accepted
+  AcceptDate: 12/2000
+  CommunicatedBy: Joachim Neubüser (Aachen)
+forms:
+  Status: accepted
+  AcceptDate: 03/2009
+  CommunicatedBy: Leonard Soicher (London)
+fplsa:
+  Status: accepted
+  AcceptDate: 07/1999
+  CommunicatedBy: Steve Linton (St Andrews)
+fr:
+  Status: deposited
+  CommunicatedBy: Götz Pfeiffer (NUI Galway)
+francy:
+  Status: deposited
+fwtree:
+  Status: deposited
+gapdoc:
+  Status: accepted
+  AcceptDate: 10/2006
+  CommunicatedBy: Steve Linton (St Andrews)
+gauss:
+  Status: deposited
+gaussforhomalg:
+  Status: deposited
+gbnp:
+  Status: accepted
+  AcceptDate: 05/2010
+  CommunicatedBy: Alexander Hulpke (Fort Collins, CO)
+generalizedmorphismsforcap:
+  Status: deposited
+genss:
+  Status: deposited
+gradedmodules:
+  Status: deposited
+gradedringforhomalg:
+  Status: deposited
+grape:
+  Status: accepted
+  AcceptDate: 07/1993
+  CommunicatedBy: Leonard Soicher (QMUL)
+groupoids:
+  Status: accepted
+  AcceptDate: 05/2015
+  CommunicatedBy: Derek Holt (Warwick)
+grpconst:
+  Status: accepted
+  AcceptDate: 07/1999
+  CommunicatedBy: Charles Wright (Eugene)
+guarana:
+  Status: deposited
+guava:
+  Status: accepted
+  AcceptDate: 02/2003
+  CommunicatedBy: Charles Wright (Eugene)
+hap:
+  Status: accepted
+  AcceptDate: 03/2006
+  CommunicatedBy: Derek Holt (Warwick)
+hapcryst:
+  Status: deposited
+hecke:
+  Status: deposited
+help:
+  Status: deposited
+homalg:
+  Status: deposited
+homalgtocas:
+  Status: deposited
+idrel:
+  Status: accepted
+  AcceptDate: 05/2015
+  CommunicatedBy: Leonard Soicher (QMUL)
+images:
+  Status: deposited
+intpic:
+  Status: deposited
+io:
+  Status: deposited
+io_forhomalg:
+  Status: deposited
+irredsol:
+  Status: accepted
+  AcceptDate: 08/2006
+  CommunicatedBy: Gerhard Hiss (Aachen)
+itc:
+  Status: accepted
+  AcceptDate: 03/2000
+  CommunicatedBy: Edmund F. Robertson (St Andrews)
+json:
+  Status: deposited
+jupyterkernel:
+  Status: deposited
+jupyterviz:
+  Status: deposited
+kan:
+  Status: accepted
+  AcceptDate: 05/2015
+  CommunicatedBy: Leonard Soicher (QMUL)
+kbmag:
+  Status: accepted
+  AcceptDate: 07/2003
+  CommunicatedBy: Charles Wright (Oregon)
+laguna:
+  Status: accepted
+  AcceptDate: 06/2003
+  CommunicatedBy: Herbert Pahlings (Aachen)
+liealgdb:
+  Status: accepted
+  AcceptDate: 09/2007
+  CommunicatedBy: Bettina Eick (Braunschweig)
+liepring:
+  Status: accepted
+  AcceptDate: 09/2014
+  CommunicatedBy: Leonard Soicher (London)
+liering:
+  Status: accepted
+  AcceptDate: 12/2013
+  CommunicatedBy: Max Neunhoeffer (Cologne)
+linearalgebraforcap:
+  Status: deposited
+localizeringforhomalg:
+  Status: deposited
+loops:
+  Status: accepted
+  AcceptDate: 05/2015
+  CommunicatedBy: Leonard Soicher (QMUL)
+lpres:
+  Status: accepted
+  AcceptDate: 09/2018
+  CommunicatedBy: Alexander Konovalov (St Andrews)
+majoranaalgebras:
+  Status: deposited
+mapclass:
+  Status: accepted
+  AcceptDate: 11/2011
+  CommunicatedBy: Leonard Soicher (QMUL)
+matgrp:
+  Status: deposited
+matricesforhomalg:
+  Status: deposited
+modisom:
+  Status: accepted
+  AcceptDate: 11/2013
+  CommunicatedBy: Olexandr Konovalov (St Andrews)
+modulepresentationsforcap:
+  Status: deposited
+modules:
+  Status: deposited
+monoidalcategories:
+  Status: deposited
+nconvex:
+  Status: deposited
+nilmat:
+  Status: accepted
+  AcceptDate: 08/2007
+  CommunicatedBy: Derek Holt (Warwick)
+nock:
+  Status: accepted
+  AcceptDate: 07/2019
+  CommunicatedBy: Leonard Soicher (QMUL)
+normalizinterface:
+  Status: deposited
+nq:
+  Status: accepted
+  AcceptDate: 01/2003
+  CommunicatedBy: Joachim Neubüser (RWTH Aachen)
+numericalsgps:
+  Status: accepted
+  AcceptDate: 05/2015
+  CommunicatedBy: Leonard Soicher (QMUL)
+openmath:
+  Status: accepted
+  AcceptDate: 08/2010
+  CommunicatedBy: David Joyner (Annapolis)
+orb:
+  Status: deposited
+packagemanager:
+  Status: deposited
+patternclass:
+  Status: deposited
+permut:
+  Status: accepted
+  AcceptDate: 04/2014
+  CommunicatedBy: Alice Niemeyer (Perth)
+polenta:
+  Status: accepted
+  AcceptDate: 08/2005
+  CommunicatedBy: Charles Wright (Eugene)
+polycyclic:
+  Status: accepted
+  AcceptDate: 01/2004
+  CommunicatedBy: Charles Wright (Eugene)
+polymaking:
+  Status: deposited
+primgrp:
+  Status: deposited
+profiling:
+  Status: deposited
+qpa:
+  Status: deposited
+quagroup:
+  Status: accepted
+  AcceptDate: 10/2003
+  CommunicatedBy: Gerhard Hiss (Aachen)
+radiroot:
+  Status: accepted
+  AcceptDate: 02/2007
+  CommunicatedBy: Edmund Robertson (St Andrews)
+rcwa:
+  Status: accepted
+  AcceptDate: 04/2005
+  CommunicatedBy: Bettina Eick (Braunschweig)
+rds:
+  Status: accepted
+  AcceptDate: 02/2008
+  CommunicatedBy: Leonard Soicher (Queen Mary, London)
+recog:
+  Status: deposited
+repndecomp:
+  Status: deposited
+repsn:
+  Status: accepted
+  AcceptDate: 05/2004
+  CommunicatedBy: Charles Wright (Eugene)
+resclasses:
+  Status: deposited
+ringsforhomalg:
+  Status: deposited
+sco:
+  Status: deposited
+scscp:
+  Status: accepted
+  AcceptDate: 08/2010
+  CommunicatedBy: David Joyner (Annapolis)
+semigroups:
+  Status: deposited
+sglppow:
+  Status: accepted
+  AcceptDate: 08/2016
+  CommunicatedBy: Leonard Soicher (QMUL)
+sgpviz:
+  Status: deposited
+simpcomp:
+  Status: accepted
+  AcceptDate: 11/2013
+  CommunicatedBy: Graham Ellis (Galway)
+singular:
+  Status: deposited
+sl2reps:
+  Status: deposited
+sla:
+  Status: accepted
+  AcceptDate: 01/2016
+  CommunicatedBy: Leonard Soicher (QMUL)
+smallgrp:
+  Status: accepted
+  AcceptDate: 02/2002
+  CommunicatedBy: Mike Newman (Canberra)
+smallsemi:
+  Status: deposited
+sonata:
+  Status: accepted
+  AcceptDate: 04/2003
+  CommunicatedBy: Charles R.B. Wright (Univ. of Oregon)
+sophus:
+  Status: accepted
+  AcceptDate: 10/2004
+  CommunicatedBy: Olexandr Konovalov (Zaporizhzhia)
+spinsym:
+  Status: deposited
+standardff:
+  Status: dev
+symbcompcc:
+  Status: accepted
+  AcceptDate: 11/2011
+  CommunicatedBy: Mike Newman (Canberra, Australia)
+thelma:
+  Status: deposited
+tomlib:
+  Status: deposited
+toolsforhomalg:
+  Status: deposited
+toric:
+  Status: accepted
+  AcceptDate: 10/2005
+  CommunicatedBy: Gerhard Hiss (Aachen)
+toricvarieties:
+  Status: deposited
+transgrp:
+  Status: deposited
+ugaly:
+  Status: accepted
+  AcceptDate: 07/2021
+  CommunicatedBy: Laurent Bartholdi (Göttingen)
+unipot:
+  Status: deposited
+unitlib:
+  Status: accepted
+  AcceptDate: 03/2007
+  CommunicatedBy: Bettina Eick (Braunschweig)
+utils:
+  Status: deposited
+uuid:
+  Status: deposited
+walrus:
+  Status: deposited
+wedderga:
+  Status: accepted
+  AcceptDate: 01/2008
+  CommunicatedBy: Gerhard Hiss (Aachen)
+xgap:
+  Status: accepted
+  AcceptDate: 07/1999
+  CommunicatedBy: Gerhard Hiß (Aachen)
+xmod:
+  Status: accepted
+  AcceptDate: 12/1996
+  CommunicatedBy: Derek Holt (Warwick)
+xmodalg:
+  Status: deposited
+yangbaxter:
+  Status: deposited
+zeromqinterface:
+  Status: deposited

--- a/_includes/packagelink_list_accepted.html
+++ b/_includes/packagelink_list_accepted.html
@@ -1,8 +1,9 @@
 <ul>
 {% assign pkgs = site.data.package-infos[site.data.release.version-safe] | sort %}
 {% for pkg in pkgs %}
-    {% if pkg[1].Status == "accepted" %}
-        {% assign name=pkg[0] %}
+    {% assign name=pkg[0] %}
+    {% assign pkgstatus = site.data.package_status[name] %}
+    {% if pkgstatus.Status == "accepted" %}
         {% unless site.data.data_libs contains name %}
             <li>{% include packagelink_generate.html pkg=name %}</li>
         {% endunless %}

--- a/_includes/packagelink_list_deposited.html
+++ b/_includes/packagelink_list_deposited.html
@@ -1,8 +1,9 @@
 <ul>
 {% assign pkgs = site.data.package-infos[site.data.release.version-safe] | sort %}
 {% for pkg in pkgs %}
-    {% if pkg[1].Status != "accepted" %}
-        {% assign name=pkg[0] %}
+    {% assign name=pkg[0] %}
+    {% assign pkgstatus = site.data.package_status[name] %}
+    {% if pkgstatus.Status != "accepted" %}
         {% unless site.data.data_libs contains name %}
             <li>{% include packagelink_generate.html pkg=name %}</li>
         {% endunless %}

--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -4,6 +4,7 @@ layout: start
 
 {% assign namelowercase = page.title | downcase %}
 {% assign pkginfo = site.data.package-infos[site.data.release.version-safe][namelowercase] %}
+{% assign pkgstatus = site.data.package_status[namelowercase] %}
 {% capture manual %}{{ site.docsurl }}/pkg/{{ namelowercase }}{% endcapture %}
 
 <h1>GAP package {{ pkginfo.PackageName }}</h1>
@@ -63,13 +64,13 @@ layout: start
 
 <dt>Status</dt> 
 <dd>
-    {{ pkginfo.Status }}
-    {% if pkginfo contains "CommunicatedBy" and pkginfo contains "AcceptDate" %}
-        &nbsp;&nbsp; (communicated by {{pkginfo.CommunicatedBy}}, accepted {{ pkginfo.AcceptDate | date: "%d/%m/%Y" }})
-    {% elsif pkginfo contains "CommunicatedBy" %}
-        &nbsp;&nbsp; (communicated by {{pkginfo.CommunicatedBy}})
-    {% elsif pkginfo contains "AcceptDate" %}
-        &nbsp;&nbsp; (accepted {{ pkginfo.AcceptDate | date: "%d/%m/%Y" }})
+    {{ pkgstatus.Status }}
+    {% if pkgstatus contains "CommunicatedBy" and pkgstatus contains "AcceptDate" %}
+        &nbsp;&nbsp; (communicated by {{pkgstatus.CommunicatedBy}}, accepted {{ pkgstatus.AcceptDate | date: "%d/%m/%Y" }})
+    {% elsif pkgstatus contains "CommunicatedBy" %}
+        &nbsp;&nbsp; (communicated by {{pkgstatus.CommunicatedBy}})
+    {% elsif pkgstatus contains "AcceptDate" %}
+        &nbsp;&nbsp; (accepted {{ pkgstatus.AcceptDate | date: "%d/%m/%Y" }})
     {% endif %}
 </dd>
 


### PR DESCRIPTION
Instead of letting each package keep track of its own status as a
deposited or refereed package, we now collect this information
centrally. This makes more sense, and also avoids some awkwardness

For example, in order to be accepted for distribution, currently GAP
package authors must provide a proper release of their package, which
then is reviewed. But that release should not yet have status `accepted`
resp. `deposited`... so strictly speaking, right after the package is
officially accepted, a second release with the updated status should be
made right away.

With a centralized list of deposited and accepted packages, there is no
need anymore for packages metadata to contain this information.
