### PR TITLE
Fix broken links found by linkchecker

### DIFF
--- a/About/index.md
+++ b/About/index.md
@@ -27,7 +27,7 @@ packages provide links to other systems.
 
 
 ### GAP provides:
-- <a href="overview.html#mathematical-capabilities">Mathematical capabilities</a>,
+- <a href="/capabilities/">Mathematical capabilities</a>,
 - A {% include ref.html label="The Programming Language" text="programming language" %},
   also called GAP,
 - An {% include ref.html label="Main Loop and Break Loop" text="interactive environment" %}.

--- a/index.md
+++ b/index.md
@@ -54,7 +54,7 @@ There is an [extensive documentation](Doc/doc.html) advising how to
 write a GAP code. Also there is a
 [guidance](https://gap-packages.github.io/example/) on
 developing a [GAP package](packages) and its
-[submission](Packages/Authors/submit.html) to GAP.
+[submission](packages/authors/submit.html) to GAP.
 
 
 ### Acknowledgements

--- a/packages/authors/authors.md
+++ b/packages/authors/authors.md
@@ -43,7 +43,7 @@ There are different ways to create a new package.
 As the number of packages and library modules in GAP grows, it is important to
 try to avoid clashes where two independently developed pieces of code use the
 same global  variable names in inconsistent ways.  See the page
-[Use of Global Variable Names]({{ site.baseurl }}/Packages/Authors/variablenames.html)
+[Use of Global Variable Names]({{ site.baseurl }}/packages/authors/variablenames.html)
 as well as the subsection
 {%- include ref.html label="Functions and Variables and Choices of Their Names" text="Functions and Variables and Choices of Their Names" %}
 of the GAP Reference Manual

--- a/packages/authors/submit.md
+++ b/packages/authors/submit.md
@@ -14,7 +14,7 @@ only accept new deposited packages.
 
 Irrespective of this, you may consider organizing and maybe
 distributing your code in the form of a GAP package. The page
-[Information for GAP Package Authors]({{ site.baseurl }}/Packages/Authors/authors.html)
+[Information for GAP Package Authors]({{ site.baseurl }}/packages/authors/authors.html)
 give detailed advice how to do this.
 
 ### Submitting Deposited Contributions


### PR DESCRIPTION
Used pyhton package(?) linkchecker, as it can recursively check any links found on a website. It found the following:
```
Statistics:
Downloaded: 10.5MB.
Content types: 1 image, 175 text, 0 video, 0 audio, 2 application, 4 mail and 6592 other.
URL lengths: min=15, max=168, avg=46.

That's it. 6774 links in 6775 URLs checked. 3 warnings found. 9 errors found.
Stopped checking at 2024-08-26 15:34:22+001 (58 seconds)
```
I fixed all the links that did not originate from dev.gap-system.org not having the archieve.