### PR TITLE
Tiny fixes

### DIFF
--- a/copyright.md
+++ b/copyright.md
@@ -36,7 +36,7 @@ the License, or (at your option) any later version.
 
 The <em>MS Windows</em> binary for
 GAP uses [cygwin](https://cygwin.com/)
-and therefore is licensed under GPL version3 or (at your option) any later version.
+and therefore is licensed under GPL version 3 or (at your option) any later version.
 For details, see
 the file `LICENSE` in the GAP distribution or see
 [The FSF's own site](https://www.gnu.org/licenses/gpl.html).

--- a/install/windows.md
+++ b/install/windows.md
@@ -31,21 +31,14 @@ Installing the GAP distribution with all the packages and full data
 libraries from source code requires a working C and C++ development
 environment on your system as well as GNU make.
 
-For users of Windows 10, we strongly recommend using GAP via the
+For users of Windows 10 or later who are familiar with Linux or Unix, we recommend using GAP via the
 [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about).
 
-Otherwise, we recommend the use of <code>.exe</code> installer which is available in the table below.
-It contains binaries for GAP (compiled with the support of GMP and readline libraries) and for selected
+If this is not possible, a <code>.exe</code> installer is available in the table below.
+It contains binaries for GAP (compiled with the support of GMP and readline libraries) and almost all
 GAP packages, and provides the standard installation procedure.
 No compilation is needed, since compiled executables for GAP
 and some packages are already provided by the <code>.exe</code> installer.
-
-Note that the path to the GAP directory should not contain spaces. For example,
-you may install GAP in <code>C:\gap-{{site.data.release.version}}</code> (default),
-<code>D:\gap-{{site.data.release.version}}</code> or
-<code>C:\Math\GAP\gap-{{site.data.release.version}}</code>, but you must not install it in a
-directory named like <code>C:\Program files\gap-{{site.data.release.version}}</code> or
-<code>C:\Users\alice\My Documents\gap-{{site.data.release.version}}</code> etc.
 
 <table>
     <colgroup>
@@ -65,7 +58,5 @@ directory named like <code>C:\Program files\gap-{{site.data.release.version}}</c
   </table>
 
 
-If you want to try to build binaries
-for more packages, you may install [Cygwin](https://www.cygwin.com)
-to get a UNIX environment for Windows, selecting all needed tools
-during Cygwin installation.
+If you want to use packages we do not build binaries for, we strongly encourage using
+the [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about).


### PR DESCRIPTION
One tiny typo, and also some minor adjustment of how we talk about windows.

In particular, putting in directories with spaces is fine, and by default we install into 'Program Files' nowadays, like any windows program.