### PR TITLE
Pre-populate packages table

### DIFF
--- a/packages/index.md
+++ b/packages/index.md
@@ -22,13 +22,16 @@ There are {{ site.data.package-infos | size }} packages that are shipped with GA
 Note that newer versions might be available on the package websites.
 
 <!-- Create a table so it can be filled by Datatables -->
+{% assign pkgs = site.data.package-infos | sort %}
 
-|   | Name | Version | Date | | Subtitle |
+|   | Name | Version | Date | Subtitle |
 |-
-| 
+{% for namepkg in site.data.package-infos -%}{%- assign pkg = namepkg[1] -%}
+|   | [{{ pkg.PackageName }}]({{ pkg.PackageWWWHome }}) | {{ pkg.Version }} | {{ pkg.Date }} | {{ pkg.Subtitle }} |
+{% endfor -%}
 |=
-|   | Name | Version | Date | | Subtitle |
+|   | Name | Version | Date | Subtitle |
 {: id="packageList" class="display"}
 
 The table above is generated using the open source software [Datatables](https://datatables.net/).
-
+It requires JavaScript to enable all features and make all data available.


### PR DESCRIPTION
... so that even users without JavaScript see at least *something*.