### PR TITLE
Update TOC and links in FAQ page

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -13,7 +13,7 @@
 }
 #faq h3:before {
     color: $grey-dk-000;
-	content: counter(heading)"." counter(subheading)"  ";
+	content: counter(subheading, lower-latin)"  ";
 	counter-increment: subheading;
 }
 

--- a/faq.md
+++ b/faq.md
@@ -5,7 +5,7 @@ nav_order: 7
 permalink: /faq/
 ---
 
-## Table of contents
+# Table of contents
 {: .no_toc .text-delta }
 
 1. TOC

--- a/faq.md
+++ b/faq.md
@@ -25,7 +25,7 @@ The brief answer is: "Yes, GAP is open source."
 
 You can use tools such as 'grep' to search for the code.
 
-Also the <a href="#2.6">answer&nbsp;to&nbsp;FAQ&nbsp;2.6</a> may be helpful.
+Also the <a href="#how-do-i-find-my-way-through-the-gap-library">answer&nbsp;to&nbsp;FAQ&nbsp;1.b</a> may be helpful.
 
 <!-- ================================================================================== -->
 


### PR DESCRIPTION
This PR addresses #364. Specifically, it ensures the first section corresponds to index 1 in the TOC, and that the questions are are indexed by lowercase letters as they are in the TOC. 

It also updates the link to an old FAQ question that now has a different name.

See screenshots below
# Current:
![image](https://github.com/user-attachments/assets/493eddc7-2e21-45a9-a966-69da8d53a56f)
[...]
![image](https://github.com/user-attachments/assets/4b0d0dac-f923-4941-9e37-b02f2acc6b1f)

# With changes from this PR:
![image](https://github.com/user-attachments/assets/dfce8885-56dd-4f92-9674-34ea4a0fdc2c)
[...]
![image](https://github.com/user-attachments/assets/b809a870-1731-450a-bd9c-b9e7d127e8b5)