### PR TITLE
Clean up whitespace around references

### DIFF
--- a/about/capabilities/algebras.md
+++ b/about/capabilities/algebras.md
@@ -8,39 +8,39 @@ permalink: /capabilities/algebras
 ---
 ## Vector Spaces, Modules and Algebras
 
-{%- include ref.html label="Vector Spaces" %} over {%- include ref.html label="Fields and Division Rings" text="fields" %} and {%- include ref.html label="Modules" text="modules" %} over {%- include ref.html label="Rings" text="rings" %} can be defined when the coefficient domain is available in GAP. Note, however, that the range of implemented methods will depend on the coefficient domain.
+{% include ref.html label="Vector Spaces" %} over {% include ref.html label="Fields and Division Rings" text="fields" %} and {% include ref.html label="Modules" text="modules" %} over {% include ref.html label="Rings" text="rings" %} can be defined when the coefficient domain is available in GAP. Note, however, that the range of implemented methods will depend on the coefficient domain.
 
-There are algorithms for the efficient calculation of Hermite and Smith {%- include ref.html label="Normal Forms over the Integers" text="normal forms" %} over the integers (see also the package [EDIM](https://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM)).
+There are algorithms for the efficient calculation of Hermite and Smith {% include ref.html label="Normal Forms over the Integers" text="normal forms" %} over the integers (see also the package [EDIM](https://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM)).
 
 Computations concerning special modules arising in representation theory
 are possible. The [hecke](https://gap-packages.github.io/hecke/) package
 allows dealing with Specht modules.
 
-{%- include ref.html label="Lie Algebras" %}
+{% include ref.html label="Lie Algebras" %}
 can be given by structure constants, by generating matrices or by
-a finite presentation. There are routines for computing the structure 
+a finite presentation. There are routines for computing the structure
 of finite dimensional Lie algebras, in particular
 there are functions for computing Cartan subalgebras,
 the direct sum decomposition, a Levi decomposition, the solvable radical
-and nil radicals. 
+and nil radicals.
 
 Much of the support for Lie  algebras is based on more general methods
 using  an implementation  of the  arithmetic operations  via structure
 constants,  which  works  for  any  finite  dimensional  algebra.   In
-particular, associative {%- include ref.html label="Algebras" text="algebras" %} (e.g., group rings, cf. the manual chapter {%- include ref.html label="Magma Rings" %}) are also supported. 
+particular, associative {% include ref.html label="Algebras" text="algebras" %} (e.g., group rings, cf. the manual chapter {% include ref.html label="Magma Rings" %}) are also supported.
 
 Investigation of algebras given by presentations are currently restricted to Lie algebras using the package [FPLSA](https://gap-packages.github.io/FPLSA); associative algebras will have to wait for a GAP 4 implementation of the vector enumeration method.
 
-The  package  [Sophus](https://gap-packages.github.io/sophus/) deals  with 
-nilpotent Lie algebras over prime fields allowing to construct central 
+The  package  [Sophus](https://gap-packages.github.io/sophus/) deals  with
+nilpotent Lie algebras over prime fields allowing to construct central
 extensions and to determine their automorphism groups.
 
-The package [QuaGroup](https://gap-packages.github.io/quagroup/) allows to 
+The package [QuaGroup](https://gap-packages.github.io/quagroup/) allows to
 investigate quantum groups.
 
 On the home page of [Jan Draisma](https://web.archive.org/web/20240414220737/https://mathsites.unibe.ch/jdraisma/) functions for working with the Weyl algebra and for the realisation of Lie algebras by means of derivations are found.
 
-Four new packages for Lie algebras appeared in GAP 4.7 
+Four new packages for Lie algebras appeared in GAP 4.7
 distribution:
 - The package [CoReLG](https://gap-packages.github.io/corelg/) for calculations in real semisimple Lie algebras.
 - The package [LieRing](https://gap-packages.github.io/liering/) for constructing finitely-presented Lie rings and calculating the Lazard correspondence. The package also provides a database of small $n$-Engel Lie rings.

--- a/about/capabilities/basic.md
+++ b/about/capabilities/basic.md
@@ -10,13 +10,13 @@ permalink: /capabilities/basic
 
 GAP provides many ways of forming ...
 
- - {% include ref.html label="Lists" text="lists" %} (mutable and 
+ - {% include ref.html label="Lists" text="lists" %} (mutable and
    [immutable]({{ site.baseurl }}/faq/#immutable)), which also covers
-   {%- include ref.html label="Sorted Lists and Sets" text="sets" %},
-   {%- include ref.html label="Row Vectors" text="row vectors" %},
-   {%- include ref.html label="Matrices" text="matrices" %},
-   {%- include ref.html label="Strings and Characters" text="strings" %}, and
-   {%- include ref.html label="Boolean Lists" text="Boolean lists" %},
+   {% include ref.html label="Sorted Lists and Sets" text="sets" %},
+   {% include ref.html label="Row Vectors" text="row vectors" %},
+   {% include ref.html label="Matrices" text="matrices" %},
+   {% include ref.html label="Strings and Characters" text="strings" %}, and
+   {% include ref.html label="Boolean Lists" text="Boolean lists" %},
  - {% include ref.html label="Records" text="records" %},
  - {% include ref.html label="Domains and their Elements" text="domains" %},
     i. e., objects representing sets with an algebraic structure.
@@ -25,7 +25,7 @@ Notions and tools modeled in some analogy to elementary set theory help
 to handle these:
 
 - distinction of
-  {%- include ref.html label="Objects and Elements" text="objects and elements" %},
+  {% include ref.html label="Objects and Elements" text="objects and elements" %},
 - {% include ref.html label="Booleans" text="Booleans" %},
 - {% include ref.html label="Orderings" text="orderings" %},
 - {% include ref.html label="Mappings" text="mappings" %} (in particular
@@ -38,23 +38,23 @@ GAP can compute with
 - arbitrary {% include ref.html label="Integers" text="integers" %},
 - {% include ref.html label="Rational Numbers" text="rational numbers" %},
 - {% include ref.html label="Cyclotomic Numbers" text="cyclotomic numbers" %}, in particular
-  {%- include ref.html label="Gaussians" text="Gaussian numbers" %},
-- elements of {%- include ref.html label="Finite Fields" text="finite fields" %} (see also the coding theory package
+  {% include ref.html label="Gaussians" text="Gaussian numbers" %},
+- elements of {% include ref.html label="Finite Fields" text="finite fields" %} (see also the coding theory package
   [GUAVA](https://gap-packages.github.io/guava/)),
 - {% include ref.html label="p-adic Numbers (preliminary)" text="<em>p</em>-adic numbers" %},
 - {% include ref.html label="Polynomials and Rational Functions" text="polynomials" %}, including
-  {%- include ref.html label="Multivariate Polynomials" text="multivariate polynomials" %} (GAP contains
+  {% include ref.html label="Multivariate Polynomials" text="multivariate polynomials" %} (GAP contains
   only a basic implementation of Buchberger's algorithm for computing
-  {%- include ref.html label="Groebner Bases" text="Gröbner bases" %},
+  {% include ref.html label="Groebner Bases" text="Gröbner bases" %},
   for more serious computations the package
   [singular](https://gap-packages.github.io/singular/) provides an interface
   to the extensive capabilities of the system
   [SINGULAR](http://www.singular.uni-kl.de)),
 - {% include ref.html label="Rational Function Families" text="rational functions" %} as well as
 - various kinds of [group elements](groups.html), e. g.
-  {%- include ref.html label="Permutations" text="permutations" %},
-  {%- include ref.html label="Matrices" text="matrices" %}, and
-  {%- include ref.html label="Words" text="abstract words" %}.
+  {% include ref.html label="Permutations" text="permutations" %},
+  {% include ref.html label="Matrices" text="matrices" %}, and
+  {% include ref.html label="Words" text="abstract words" %}.
 
 One can work with many algebraic structures. In addition to those listed under
 [Mathematical Capabilities]({{ site.baseurl }}/capabilities/#mathematical-capabilities), there are e. g.
@@ -67,9 +67,9 @@ One can work with many algebraic structures. In addition to those listed under
 
 Also there are
 
-- various {%- include ref.html label="Combinatorics" text="combinatorial functions" %},
+- various {% include ref.html label="Combinatorics" text="combinatorial functions" %},
 - functions for
-  {%- include ref.html label="Number Theory" text="elementary number theory" %} as well as
+  {% include ref.html label="Number Theory" text="elementary number theory" %} as well as
 - functions for
-  {%- include ref.html label="Prime Integers and Factorization" text="prime number factorization" %} (see also the package
+  {% include ref.html label="Prime Integers and Factorization" text="prime number factorization" %} (see also the package
   [FactInt](https://gap-packages.github.io/FactInt)).

--- a/about/capabilities/fpgroups.md
+++ b/about/capabilities/fpgroups.md
@@ -19,16 +19,16 @@ groups of described structure, most of which are based on the idea of
 the book "Computation with finitely presented groups" of Charles Sims.
 
 The main GAP library provides methods for handling
-{%- include ref.html label="Finitely Presented Groups" text="finitely presented groups" %} such as
+{% include ref.html label="Finitely Presented Groups" text="finitely presented groups" %} such as
 - Todd-Coxeter,
 - Reidemeister-Schreier,
 - Low Index Subgroups, as well as
 - certain quotient methods.
 
 Also there are functions to handle
-{%- include ref.html label="Presentations and Tietze Transformations" text="Tietze transformations" %}.
+{% include ref.html label="Presentations and Tietze Transformations" text="Tietze transformations" %}.
 
-In addition there are packages 
+In addition there are packages
 
 - [FGA](http://www.icm.tu-bs.de/ag_algebra/software/FGA/) providing algorithms for
   free groups,
@@ -41,4 +41,4 @@ In addition there are packages
 - [NQ](https://gap-packages.github.io/nq/) for finding infinite
   nilpotent quotients, and
 - [KBMAG](https://gap-packages.github.io/kbmag) with Knuth-Bendix
-  and automatic groups methods. 
+  and automatic groups methods.

--- a/about/capabilities/further.md
+++ b/about/capabilities/further.md
@@ -9,11 +9,11 @@ permalink: /capabilities/further
 
 These include
 - functions for the determination of
-  {%- include ref.html label="Galois Action" text="Galois groups" %}
+  {% include ref.html label="Galois Action" text="Galois groups" %}
   of rational polynomials,
 - packages
   [AClib](https://gap-packages.github.io/aclib/),
-  [Cryst](https://www.math.uni-bielefeld.de/~gaehler/gap/packages.php), 
+  [Cryst](https://www.math.uni-bielefeld.de/~gaehler/gap/packages.php),
   [CrystCat](https://www.math.uni-bielefeld.de/~gaehler/gap/packages.php) and
   [CaratInterface](https://www.math.uni-bielefeld.de/~gaehler/gap/packages.php) for
   crystallographic and almost crystallographic groups,

--- a/about/capabilities/groups.md
+++ b/about/capabilities/groups.md
@@ -9,13 +9,13 @@ permalink: /capabilities/groups
 ## Groups and Group Elements
 
 Groups can be given in various forms: for example as
-{%- include ref.html label="Permutation Groups" text="permutation groups" %} or
-{%- include ref.html label="Matrix Groups" text="matrix groups" %} (by generating elements), as
-{%- include ref.html label="Finitely Presented Groups" text="finitely presented groups" %} or as
-{%- include ref.html label="Pc Groups" text="polycyclicly presented groups" %}.
+{% include ref.html label="Permutation Groups" text="permutation groups" %} or
+{% include ref.html label="Matrix Groups" text="matrix groups" %} (by generating elements), as
+{% include ref.html label="Finitely Presented Groups" text="finitely presented groups" %} or as
+{% include ref.html label="Pc Groups" text="polycyclicly presented groups" %}.
 GAP knows how to construct a number of well-known groups
 such as symmetric and classical groups and to fetch concrete groups from
-{%- include ref.html label="Group Libraries" text="group libraries" %}.
+{% include ref.html label="Group Libraries" text="group libraries" %}.
 
 There is a wide variety of functions for the investigation of groups.
 Some of these functions just build on the concept of a group while others
@@ -23,14 +23,14 @@ Some of these functions just build on the concept of a group while others
 permutation groups) utilize the way in which a particular group is given.
 GAP tries automatically to select a good method, but the
 user can take over full control of this
-{%- include ref.html label="Method Selection" text="selection of methods" %}. Also, if
+{% include ref.html label="Method Selection" text="selection of methods" %}. Also, if
 no deterministic method exists (e. g., for determining the order of an
 fp-group) GAP will try to find an isomorphism to a group
 it can handle (in the above case it will try to find an isomorphism to a
-permutation group using the Todd-Coxeter method). 
+permutation group using the Todd-Coxeter method).
 
 There are many functions to compute
-{%- include ref.html label="Groups" text="invariants of groups" %},
+{% include ref.html label="Groups" text="invariants of groups" %},
 e. g.:
 
 - order (called 'size' in GAP),
@@ -50,8 +50,8 @@ e. g.:
   [cohomolo](https://gap-packages.github.io/cohomolo) and
   [HAP](https://gap-packages.github.io/hap)
   and manual section
-  {%- include ref.html label="1-Cohomology" text="1-cohomology" %}),
-- ordinary {%- include ref.html label="Character Tables" text="character table" %} (see also the page
+  {% include ref.html label="1-Cohomology" text="1-cohomology" %}),
+- ordinary {% include ref.html label="Character Tables" text="character table" %} (see also the page
   [Representations and Characters of Groups](representations.html)).
 
 There are also functions for

--- a/about/capabilities/index.md
+++ b/about/capabilities/index.md
@@ -10,14 +10,14 @@ permalink: /capabilities/
 
 - [Mathematical capabilities](#mathematical-capabilities) accessible through
   - a large library of
-      {%- include ref.html label="Functions" text="functions" %}, containing
+      {% include ref.html label="Functions" text="functions" %}, containing
       implementations of various algebraic algorithms.
   - separate [packages]({{ site.baseurl }}/packages/) of additional
       functions for specialized purposes which can be used like library
       functions,
   - data libraries containing large classes of various algebraic objects that are accessible by
       using GAP commands.
-- A {%- include ref.html label="The Programming Language" text="programming language" %}, 
+- A {% include ref.html label="The Programming Language" text="programming language" %},
   also called GAP,
   which is interpreted and can be compiled. It can be used interactively
   at the keyboard or to write programs to be saved and then executed.
@@ -26,23 +26,23 @@ permalink: /capabilities/
   - automatic memory management including garbage collection,
   - {% include ref.html label="Streams" text="streams" %},
   - flexible
-      {%- include ref.html label="Lists" text="list" %} and
-      {%- include ref.html label="Records" text="record" %} data types,
+      {% include ref.html label="Lists" text="list" %} and
+      {% include ref.html label="Records" text="record" %} data types,
   - built-in data types for key algebraic objects,
-  - automatic {%- include ref.html label="Method Selection" text="method selection" %} 
-      building on  a mechanism for 
-      automatically  choosing the highest ranked method for a certain 
-      operation,  depending on the current state of all its arguments, 
-      so that GAP objects representing mathematical objects may gain 
-      knowledge about themselves during their lifetime  resulting in 
+  - automatic {% include ref.html label="Method Selection" text="method selection" %}
+      building on  a mechanism for
+      automatically  choosing the highest ranked method for a certain
+      operation,  depending on the current state of all its arguments,
+      so that GAP objects representing mathematical objects may gain
+      knowledge about themselves during their lifetime  resulting in
       better methods being chosen later on.
-- An {%- include ref.html label="Main Loop and Break Loop" text="interactive environment" %} 
-  that supports in particular 
+- An {% include ref.html label="Main Loop and Break Loop" text="interactive environment" %}
+  that supports in particular
   - {% include ref.html label="Line Editing" text="line editing" %}
-      e.g. tab completion, 
+      e.g. tab completion,
   - {% include ref.html label="Break Loops" text="break loops" %}
       for debugging,
-  - further {%- include ref.html label="Debugging and Profiling Facilities" text="debugging and profiling" %}
+  - further {% include ref.html label="Debugging and Profiling Facilities" text="debugging and profiling" %}
       facilities for GAP programs,
   - {% include ref.html label="The Help System" text="online help" %}
     (i.e. online access to the manuals).

--- a/about/capabilities/permgroups.md
+++ b/about/capabilities/permgroups.md
@@ -38,10 +38,10 @@ Class-Wise  Affine   mappings  of  certain  euclidian   rings  R  into
 themselves  and the  groups generated  by bijective  mappings  of this
 type.  The latter mappings form a proper subgroup of Sym(R).
 
-For {%- include ref.html label="Matrix Groups" text="matrix groups" %}
+For {% include ref.html label="Matrix Groups" text="matrix groups" %}
 there are also special methods in the GAP library
-and a private GAP4 package 
-[matrixss](http://matrixss.sourceforge.net) 
+and a private GAP4 package
+[matrixss](http://matrixss.sourceforge.net)
 implements  a
 [Schreier-Sims algorithm for matrix groups](http://henrik.baarnhielm.net/schreiersims.pdf),
 including both the standard deterministic and the standard
@@ -49,5 +49,5 @@ probabilistic approach.
 
 The package
 [Polenta](https://gap-packages.github.io/polenta/) allows to find
-{%- include ref.html label="Pc Groups" text="polycyclic presentations" %}
+{% include ref.html label="Pc Groups" text="polycyclic presentations" %}
 for matrix groups.

--- a/about/capabilities/representations.md
+++ b/about/capabilities/representations.md
@@ -11,16 +11,16 @@ permalink: /capabilities/representations
 Group representations over fields of characteristic zero are mainly
 investigated via their characters. GAP provides methods
 for computing the irreducible characters of a given finite group, either
-{%- include ref.html label="The Dixon-Schneider Algorithm" text="automatically" %} or
-{%- include ref.html label="Class Functions" text="interactively" %}
+{% include ref.html label="The Dixon-Schneider Algorithm" text="automatically" %} or
+{% include ref.html label="Class Functions" text="interactively" %}
 by character theoretic means. It also provides many functions for
 deducing group theoretic properties from
-{%- include ref.html label="Character Tables" text="character tables" %}.
+{% include ref.html label="Character Tables" text="character tables" %}.
 
 The computation of the irreducible representations themselves is possible
 for not too large groups (see e. g. the function 'IrreducibleRepresentations'
 in the reference manual section
-{%- include ref.html label="Computing the Irreducible Characters of a Group" text="Computing the Irreducible Characters of a Group" %}).
+{% include ref.html label="Computing the Irreducible Characters of a Group" text="Computing the Irreducible Characters of a Group" %}).
 The package
 [Repsn](https://gap-packages.github.io/repsn/) provides methods for the
 construction of characteristic zero representations of finite groups.
@@ -29,7 +29,7 @@ Modular representations (i. e., over fields whose characteristic divides
 the group order) can be studied via Brauer characters or by explicit
 calculations with matrices representing the generators of the group in
 question, using
-{%- include ref.html label="The MeatAxe" text="MeatAxe" %} methods, and 
+{% include ref.html label="The MeatAxe" text="MeatAxe" %} methods, and
 [condensation techniques](http://www.math.rwth-aachen.de/~Juergen.Mueller/preprints/jm102.pdf).
 
 Several GAP data libraries are related to representations
@@ -39,7 +39,7 @@ and characters.
   [Character Table Library](https://www.math.rwth-aachen.de/~Thomas.Breuer/ctbllib)
   gives access to ordinary and modular character tables of many nearly
   simple groups and of related groups such as their maximal subgroups.
-- The [Atlas of Group Representations](https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep) gives access to 
+- The [Atlas of Group Representations](https://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep) gives access to
   many permutation and matrix representations of many nearly simple
   and related groups.
 

--- a/about/capabilities/semigroups.md
+++ b/about/capabilities/semigroups.md
@@ -10,34 +10,34 @@ permalink: /capabilities/semigroups
 
 These include
 - functions for calculating with
-  {%- include ref.html label="Transformations" text="transformations" %},
+  {% include ref.html label="Transformations" text="transformations" %},
 - functions for investigating
-  {%- include ref.html label="Semigroups" text="semigroups" %},
+  {% include ref.html label="Semigroups" text="semigroups" %},
   in particular transformation semigroups,
-  {%- include ref.html label="Monoids" text="monoids" %}, and
-  {%- include ref.html label="Finitely Presented Semigroups and Monoids" text="finitely presented semigroups and monoids" %},
+  {% include ref.html label="Monoids" text="monoids" %}, and
+  {% include ref.html label="Finitely Presented Semigroups and Monoids" text="finitely presented semigroups and monoids" %},
 - sets of basic functions for
-  {%- include ref.html label="Magmas" text="magmas" %} and
-  {%- include ref.html label="Additive Magmas" text="additive magmas" %},
+  {% include ref.html label="Magmas" text="magmas" %} and
+  {% include ref.html label="Additive Magmas" text="additive magmas" %},
 - a package
   [SONATA](https://gap-packages.github.io/sonata/) for investigating near rings,
 - a package
   [XMod](https://gap-packages.github.io/xmod/) for crossed modules and cat-1 groups,
-- a package 
-  [GPD](https://gap-packages.github.io/groupoids/) 
-  for computation of finite groupoids, 
-- a package 
+- a package
+  [GPD](https://gap-packages.github.io/groupoids/)
+  for computation of finite groupoids,
+- a package
   [Loops](https://gap-packages.github.io/loops/) for various types of loops,
-- a package 
+- a package
   [Semigroups](https://semigroups.github.io/Semigroups) (former Citrus)
   for computing with semigroups of transformations and partial permutations,
   or subsemigroups of regular Rees 0-matrix semigroups, and also with
   free inverse semigroups,
-- a package 
+- a package
   [Smallsemi](https://gap-packages.github.io/smallsemi/), providing a data library
   of all semigroups with at most 8 elements,
-- a package 
-  [NumericalSgps](https://gap-packages.github.io/numericalsgps) 
+- a package
+  [NumericalSgps](https://gap-packages.github.io/numericalsgps)
   for computations with numerical semigroups, and
-- a package 
+- a package
   [SgpViz](https://gap-packages.github.io/sgpviz) for semigroup visualization.

--- a/about/capabilities/words.md
+++ b/about/capabilities/words.md
@@ -10,21 +10,21 @@ permalink: /capabilities/words
 
 These include
 - functions for calculating with
-  {%- include ref.html label="Words" text="words" %}, in particular with
-  {%- include ref.html label="Associative Words" text="associative words" %},
+  {% include ref.html label="Words" text="words" %}, in particular with
+  {% include ref.html label="Associative Words" text="associative words" %},
 - some set of functions dealing with
-  {%- include ref.html label="Rewriting Systems" text="rewriting systems" %},
+  {% include ref.html label="Rewriting Systems" text="rewriting systems" %},
 - the package
   [kbmag](https://gap-packages.github.io/kbmag) providing the Knuth-Bendix
   method on Monoids and functions for Automatic Groups,
 - the package
   [kan](https://gap-packages.github.io/kan/) provides a collection of
-   functions for computing with all types of Kan extension, 
+   functions for computing with all types of Kan extension,
    including double coset rewriting systems.
 - the package
-  [IdRel](https://gap-packages.github.io/idrel/) provides functions 
-  for computing the identities among relators of an fp-group 
+  [IdRel](https://gap-packages.github.io/idrel/) provides functions
+  for computing the identities among relators of an fp-group
   presentation using logged rewriting.
 - the package
-  [Automata](https://gap-packages.github.io/automata/), allowing to generate 
+  [Automata](https://gap-packages.github.io/automata/), allowing to generate
   finite state automata and investigate its states.

--- a/faq.md
+++ b/faq.md
@@ -21,7 +21,7 @@ permalink: /faq/
 
 When you start GAP, it looks for files with the names
 `gap.ini` and `gaprc` in its root directories
-(see {%- include ref.html label="GAP Root Directories" %}),
+(see {% include ref.html label="GAP Root Directories" %}),
 and reads the first `gap.ini` and the first `gaprc` file it finds.
 These files may be used for certain customisations, for example, to
 read a file containing  functions or data that you always need,
@@ -30,13 +30,13 @@ personal  abbreviations for some names in the library, which seems to
 be  too  long for you.
 
 For more details about `gap.ini` and `gaprc` files see the section
-{%- include ref.html label="The gap.ini and gaprc files" text="The&nbsp;gap.ini&nbsp;and&nbsp;gaprc&nbsp;files" %}
+{% include ref.html label="The gap.ini and gaprc files" text="The&nbsp;gap.ini&nbsp;and&nbsp;gaprc&nbsp;files" %}
 from the GAP Reference Manual.
 
 In former GAP releases prior to GAP 4.5
 a filed called `.gaprc` was used for customisations. If you
 have used the `.gaprc` file, see the section
-{%- include ref.html label="The former .gaprc file" text="The&nbsp;former&nbsp;.gaprc&nbsp;file" %}.
+{% include ref.html label="The former .gaprc file" text="The&nbsp;former&nbsp;.gaprc&nbsp;file" %}.
 from the GAP Reference Manual for the transitional arrangements.
 
 <!-- ================================================================================== -->
@@ -81,7 +81,7 @@ The most convenient way of creating larger pieces of GAP
 code is to write them to some text file. For this purpose you can simply use
 your favorite text editor. You can load such a file into GAP
 using the command <tt>Read( name-file )</tt>. See the reference manual section
-{%- include ref.html label="Read" text="File&nbsp;Operations" %} for information
+{% include ref.html label="Read" text="File&nbsp;Operations" %} for information
 on these and related commands.
 
 The   command   <tt>SaveWorkspace( filename )</tt>   will  save   a
@@ -90,7 +90,7 @@ The   command   <tt>SaveWorkspace( filename )</tt>   will  save   a
 GAP  which then will  behave as  at the  point when <tt>SaveWorkspace</tt>
 was called.
 See the section
-{%- include ref.html label="SaveWorkspace" text="Saving&nbsp;and&nbsp;Loading&nbsp;a&nbsp;Workspace" %} for
+{% include ref.html label="SaveWorkspace" text="Saving&nbsp;and&nbsp;Loading&nbsp;a&nbsp;Workspace" %} for
 information on this and related commands.
 
 <!-- ================================================================================== -->
@@ -229,7 +229,7 @@ In case of running a batch job (or being irritated by this error message),
 you can use the <tt>-o</tt> command line option to set this trigger limit to
 a higher default level, e.g. the amount of physical memory your machine has.
 See the section
-{%- include ref.html label="Command Line Options" text="Command&nbsp;Line&nbsp;Options" %} in the Reference Manual for more
+{% include ref.html label="Command Line Options" text="Command&nbsp;Line&nbsp;Options" %} in the Reference Manual for more
 detail.
 </dd>
 </dl>
@@ -316,7 +316,7 @@ groups to an isomorphic permutation group. Two possible bottlenecks are:
 are immediately converted again in a permutation: Because of this it
 is often quicker to work in the isomorphic permutation group  (obtained
 via `IsomorphismPermGroup`, see the section
-'{%- include ref.html label="Computing a Permutation Representation" %}'
+'{% include ref.html label="Computing a Permutation Representation" %}'
 of the  GAP reference manual) and only to translate the final
 result back to matrix form, using the same homomorphism.
 2. GAP finds a permutation representation by acting on a set of  vectors.
@@ -324,13 +324,13 @@ There is no optimal heuristics for choosing these vectors (a
 necessary condition for faithfulness is that the vectors comprise a
 basis, but there are many choices).
 Note that `IsomorphismPermGroup`  for matrix groups internally already uses
-'{%- include ref.html label="SmallerDegreePermutationRepresentation" %}'
+'{% include ref.html label="SmallerDegreePermutationRepresentation" %}'
 (unless  the matrix  group is known  to contain SL),  thus this
 operation cannot be used to reduce the degree further.
 If the group is very large, it
 can be rather beneficial to try to choose such a set of vectors yourself and
 use `ActionHomomorphism` (see the section
-'{%- include ref.html label="The Permutation Image of an Action" %}'
+'{% include ref.html label="The Permutation Image of an Action" %}'
 of the GAP reference manual) to build the permutation representation.
 
 
@@ -462,8 +462,8 @@ back into the group `n`, using the function
 
 The answer is a clear 'no  and yes'! To understand this 'clear answer'
 let  us consider  the integers  mod  15. (See  section
-{%- include ref.html label="Residue Class Rings" text="Residue  Class Rings" %} in the chapter on
-{%- include ref.html label="Integers" text="integers" %}.)
+{% include ref.html label="Residue Class Rings" text="Residue  Class Rings" %} in the chapter on
+{% include ref.html label="Integers" text="integers" %}.)
 First  of all  you  can  simply add  and multiply integers mod 15 by
 
 ```gap
@@ -516,7 +516,7 @@ false
 
 The explanation is that  in GAP an additive group A
 (of a ring) is  just an
-{%- include ref.html label="Additive Magmas" text="additive&nbsp;magma" %}
+{% include ref.html label="Additive Magmas" text="additive&nbsp;magma" %}
 -with-zero with an operation that maps each element a of
 A to its additive inverse and  that most of the algorithms for groups
 are not available for these. So you get:
@@ -629,15 +629,15 @@ presentation must be a polycyclic presentation for
 `PcGroupFpGroup()` to work. `PcGroupFpGroup()` does
 **not** compute a polycyclic presentation for a finite soluble
 group given  by an **arbitrary** finite presentation. See
-{%- include ref.html label="Constructing Pc Groups" text="Constructing Pc Groups" %}.
+{% include ref.html label="Constructing Pc Groups" text="Constructing Pc Groups" %}.
 
 In a
-{%- include ref.html label="Pc Groups" text="polycyclic&nbsp;presentation" %}
+{% include ref.html label="Pc Groups" text="polycyclic&nbsp;presentation" %}
 the generators must occur in the  particular order of a 'polycyclic
 generating sequence':
 
 As described in the Reference Manual chapter
-{%- include ref.html label="Polycyclic Groups" text="Polycyclic&nbsp;Groups" %}
+{% include ref.html label="Polycyclic Groups" text="Polycyclic&nbsp;Groups" %}
 a group G is polycyclic if there exists a subnormal series
 G = C<sub>1</sub>> C<sub>2</sub>> ...  >  C<sub>n</sub>>
 C<sub>n+1</sub>  =  {1}  with  cyclic factors, and  a  polycyclic
@@ -785,8 +785,8 @@ of subgroups of a given size.
 
 For groups of moderate size (up to 10<sup>4</sup>/10<sup>5</sup>,
 this depends a bit on the group structure) the commands
-{%- include ref.html label="LatticeSubgroups" text="`LatticeSubgroups`" %} or
-{%- include ref.html label="ConjugacyClassesSubgroups" text="`ConjugacyClassesSubgroups`" %}
+{% include ref.html label="LatticeSubgroups" text="`LatticeSubgroups`" %} or
+{% include ref.html label="ConjugacyClassesSubgroups" text="`ConjugacyClassesSubgroups`" %}
 will compute representatives of all subgroups up to conjugacy. If the group
 gets bigger, however, this will either run out of space or take too long
 to be feasible.
@@ -796,21 +796,21 @@ subgroups. Try to use the restricting conditions to reduce the calculation
 (for example *p*-subgroups can be found inside a Sylow subgroup).
 GAP commands that might come useful to obtain specific
 subgroups are for example
-{%- include ref.html label="NormalSubgroups" text="`NormalSubgroups`" %},
-{%- include ref.html label="SylowSubgroup" text="`SylowSubgroup`" %},
-{%- include ref.html label="HallSubgroup" text="`HallSubgroup`" %},
+{% include ref.html label="NormalSubgroups" text="`NormalSubgroups`" %},
+{% include ref.html label="SylowSubgroup" text="`SylowSubgroup`" %},
+{% include ref.html label="HallSubgroup" text="`HallSubgroup`" %},
 or
-{%- include ref.html label="MaximalSubgroupClassReps" text="`MaximalSubgroupClassReps`" %}.
+{% include ref.html label="MaximalSubgroupClassReps" text="`MaximalSubgroupClassReps`" %}.
 
 Furthermore, if you actually want to know if the group has a subgroup of a
 particular isomorphism type, the command you want is
-{%- include ref.html label="IsomorphicSubgroups" text="`IsomorphicSubgroups`" %}.
+{% include ref.html label="IsomorphicSubgroups" text="`IsomorphicSubgroups`" %}.
 This is enormously more efficient than simply listing all [conjugacy classes of] subgroups of
 the group in most cases.
 
 It might also be helpful to first replace the group by an isomorphic permutation group
-(using {%- include ref.html label="IsomorphismPermGroup" text="`IsomorphismPermGroup`" %})
-or pc group (using {%- include ref.html label="IsomorphismPcGroup" text="`IsomorphismPcGroup`" %}).
+(using {% include ref.html label="IsomorphismPermGroup" text="`IsomorphismPermGroup`" %})
+or pc group (using {% include ref.html label="IsomorphismPcGroup" text="`IsomorphismPcGroup`" %}).
 
 <!-- ================================================================================== -->
 
@@ -1048,18 +1048,18 @@ However GAP has methods to investigate  each such presentation   for any
 given (not too big) prime $p$. In her reply Bettina Eick recommends:
 
 > you can use GAP to investigate your question for any fixed prime p.
-> 
+>
 > For example, the nilpotent quotient algorithm of the NQ package or the
 > NQL package of GAP allows you to determine the largest class-c quotient
 > of a finitely presented group for any positive integer c or even the
 > largest nilpotent quotient (if this exists).
-> 
+>
 > Further, there are methods available in GAP to determine the automorphism
 > group of a finite $p$-group. Check the AutPGrp package for this purpose.
-> 
+>
 > In your given example, you can implement your considered group $G$ in GAP
 > as function in $p$:
-> 
+>
 > ```gap
 > G := function(p)
 >     local F, f, r, a, b, c;
@@ -1072,16 +1072,16 @@ given (not too big) prime $p$. In her reply Bettina Eick recommends:
 >     return F/r;
 > end;
 > ```
-> 
+>
 > Then you load the relevant packages
-> 
+>
 > ```gap
 > LoadPackage("nq");
 > LoadPackage("autpgrp");
 > ```
-> 
+>
 > And then you can do the following (for example for $p=3$):
-> 
+>
 > ```gap
 > gap> H := G(3);
 > [fp group on the generators [ f1, f2, f3 ]]
@@ -1093,7 +1093,7 @@ given (not too big) prime $p$. In her reply Bettina Eick recommends:
 > gap> A.size;
 > 14348907
 > ```
-> 
+>
 > Hence for $p=3$ your group has class $2$ and you can see the size
 > of its automorphism group. Generators and further information on
 > the automorphisms is also stored in A, but is perhaps too long to
@@ -1105,16 +1105,16 @@ In a second letter Derek Holt recommends:
 > groups, using the method described by Charles Sims in his book of computing
 > in finitely presented groups. This uses the Knuth-Bendix completion
 > algorithm.
-> 
+>
 > This process is described and illustrated in Example 4 (p. 13) of the KBMAG
 > manual. I have successfully verifed that your group below is nilpotent of
 > order $p^{10}$ for $p=2,3,5,7,11,13,17,$ and I am trying to do $19$.
-> 
+>
 > Of course, since these groups are (apparently) finite, you could try
 > use coset enumeration. This will work for small primes such as $2$ and $3$, but
 > for larger primes the group order will probably be too large, and I think
 > the Sims algorithm will work better.
-> 
+>
 > You first run `NilpotentQuotient` (as described in Bettina Eick's reply) to
 > find the maximal nilpotent quotient of your group. The aim is then to
 > prove that the group is actually isomorphic to this quotient.
@@ -1123,9 +1123,9 @@ In a second letter Derek Holt recommends:
 > quotient. You order the generators so that those at the bottom of the
 > group come first and then use the so-called recursive ordering on strings
 > to run Knuth-Bendix.
-> 
+>
 > Here is the basic GAP code to do this.
-> 
+>
 > ```gap
 > LoadPackage("kbmag");
 > SetInfoLevel(InfoRWS,2);
@@ -1140,19 +1140,19 @@ In a second letter Derek Holt recommends:
 > SetOrderingOfKBMAGRewritingSystem(R, "recursive");
 > MakeConfluent(R);
 > ```
-> 
+>
 > If successful it will halt with a confluent presentation containing the
 > relations of the power-commutator presentation of the computed maximal
 > nilpotent quotient. You have then proved that these relations hold in
 > the group itself (not just in the nilptent quotient), so you have proved
 > that the group is nilpotent.  This consists of 65 reduction equations
 > (or $62$ when $p=2$).
-> 
+>
 > The above works quickly for $p=2,3,5,7$. For larger primes, it helps to
 > restrict the length of the stored reduction relations, and then re-run
 > after completion. You have to experiment to find the optimal maximal
 > length to store.  So, for example, the following works fast for $p=17$:
-> 
+>
 > ```gap
 > p:=17;;
 > rels := [a^p/e, b^p/f, c^p/d, e^p/g, f^p/h, g^p/i, i^p/j,
@@ -1371,19 +1371,19 @@ S (1 gens, size 3)
 ### Can non-isomorphic groups have equal structure descriptions?
 
 Yes, indeed, this can happen.
-{%- include ref.html label="StructureDescription" text="The manual entry for \"StructureDescription\"" %}
+{% include ref.html label="StructureDescription" text="The manual entry for \"StructureDescription\"" %}
 says: "The   string  returned  by  StructureDescription  is  NOT  an  isomorphism
 invariant:  non-isomorphic  groups  can  have the same string value, and two
 isomorphic   groups  in  different  representations  can  produce  different
 strings."
 
-{%- include ref.html label="StructureDescription" text="StructureDescription" %}
+{% include ref.html label="StructureDescription" text="StructureDescription" %}
 provides an "informal" overview of the structure of a group, which is a useful
 first view for small groups. More sophisticated functions in the same area include:
-{%- include ref.html book="smallgrp" label="IdGroup" text="IdGroup" %}; the
+{% include ref.html book="smallgrp" label="IdGroup" text="IdGroup" %}; the
 `StandardPresentation`
 function of the [ANUPQ package](https://gap-packages.github.io/anupq/) and
-{%- include ref.html label="IsomorphismGroups" text="IsomorphismGroups" %},
+{% include ref.html label="IsomorphismGroups" text="IsomorphismGroups" %},
 each of which is described in the appropriate manual.
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
@@ -1413,7 +1413,7 @@ There are several C and C++ libraries that implement the client side.
 ### Where is the GAP file editor? How do I save GAP programs?
 
 GAP programs are simple text files, and you can edit them with
-any text editor. Some editors may support GAP syntax highlighting and have 
+any text editor. Some editors may support GAP syntax highlighting and have
 other useful features:
 
 - [BBEdit](https://www.barebones.com/products/bbedit/index.shtml) for macOS,
@@ -1449,7 +1449,7 @@ other useful features:
   by {% include namelink.html name="Olexandr Konovalov" %})
 
 - [vim](https://www.vim.org/)
-  (see {%- include ref.html label="Editor Support" %}
+  (see {% include ref.html label="Editor Support" %}
   and the 'etc' directory of the GAP installation)
 
 - [Visual Studio Code](https://code.visualstudio.com/) for Linux, Windows, macOS,

--- a/install/index.md
+++ b/install/index.md
@@ -19,9 +19,9 @@ There are several ways to install GAP:
 More detailed instructions can be found in [INSTALL.md](https://github.com/gap-system/gap/blob/v{{site.data.release.version}}/INSTALL.md).
 
 
-GAP may compile and work for you on other systems, and if so we would 
+GAP may compile and work for you on other systems, and if so we would
 be interested to know about it.
-<!-- 
+<!--
 You can also try GAP online in a [Jupyter](https://jupyter.org/)
 notebook running on [Binder](https://mybinder.org/), following
 instructions from the README file in <a
@@ -38,7 +38,7 @@ would like to be installed or any questions you might have
 
 ### Getting Started
 
-If you followed all instruction steps you can test you installation as described below. 
+If you followed all instruction steps you can test you installation as described below.
 If it works and you are new to GAP you may try to start reading and
 trying the examples in the first chapters of the <a
 href="{{ site.docsurl }}/doc/tut/chap0_mj.html">Tutorial</a>
@@ -50,9 +50,9 @@ from inside GAP.
 ### Testing the Installation<a name="Test"></a>
 
 For a quick test of your installation you may start GAP.
-Normally, you will see a GAP&nbsp;4 banner and the information about loaded 
-components and packages. This information may vary depending 
-on  your installation.  For  example,  for  the complete installation of 
+Normally, you will see a GAP&nbsp;4 banner and the information about loaded
+components and packages. This information may vary depending
+on  your installation.  For  example,  for  the complete installation of
 latest versions of all packages you will have something like:
 
 ```
@@ -70,7 +70,7 @@ latest versions of all packages you will have something like:
              ResClasses 4.7.3, SmallGrp 1.5.3, Sophus 1.27, SpinSym 1.5.2,
              StandardFF 1.0, TomLib 1.2.11, TransGrp 3.6.5, utils 0.85
  Try '??help' for help. See also '?copyright', '?cite' and '?authors'
-gap> 
+gap>
 ```
 
 Now you may
@@ -120,11 +120,11 @@ it contains some additional remarks and troubleshooting advices.
 #### Upgrading
 
 If you have any version of GAP older than the current version, the only way to install a new version of GAP is a new installation.
-If you installed GAP from the standard distribution and have not manually installed additional or 
+If you installed GAP from the standard distribution and have not manually installed additional or
 updated packages in your GAP distribution (which is no
-longer necessary -- instead we recommend that you 
-install them in the 
-{%- include ref.html label="GAP Root Directories" text="user specific GAP root directory" %}) 
-then you can always upgrade to the latest version of GAP by moving the old version aside 
-and downloading and installing the current archives, and this is the approach we recommend 
+longer necessary -- instead we recommend that you
+install them in the
+{% include ref.html label="GAP Root Directories" text="user specific GAP root directory" %})
+then you can always upgrade to the latest version of GAP by moving the old version aside
+and downloading and installing the current archives, and this is the approach we recommend
 for most users. Make sure that you update any scripts or links to refer to the new version.

--- a/packages/authors/index.md
+++ b/packages/authors/index.md
@@ -18,7 +18,7 @@ package authors have done.)
 ### Getting Started Writing a Package
 
 The GAP Reference Manual contains a
-{%- include ref.html label="Using and Developing GAP Packages" text="chapter on using and developing GAP packages" %},
+{% include ref.html label="Using and Developing GAP Packages" text="chapter on using and developing GAP packages" %},
 which describes the rules and conventions for the structure of a GAP package,
 and the GAP functions that deal with package administration.
 
@@ -46,7 +46,7 @@ try to avoid clashes where two independently developed pieces of code use the
 same global  variable names in inconsistent ways.  See the page
 [Use of Global Variable Names]({{ site.baseurl }}/packages/authors/variablenames.html)
 as well as the subsection
-{%- include ref.html label="Functions and Variables and Choices of Their Names" text="Functions and Variables and Choices of Their Names" %}
+{% include ref.html label="Functions and Variables and Choices of Their Names" text="Functions and Variables and Choices of Their Names" %}
 of the GAP Reference Manual
 for advice how to avoid such 'name clashes'.
 
@@ -102,7 +102,7 @@ XML-like language. This documentation can then be processed using GAPDoc to
 produce on-line help, printed manuals, and web pages.
 (To get machine independent cross-links in your documentation, copy
 your package in the standard location `pkg/<pkgname>`
-and use {%- include ref.html book="GAPDoc" label="MakeGAPDocDoc" %}
+and use {% include ref.html book="GAPDoc" label="MakeGAPDocDoc" %}
 with `../../..` as 5th argument.)
 
 Alternatively, you can use the "traditional" GAP4 manual format, i.e. TeX
@@ -121,7 +121,7 @@ version of your manual to get cross-links right.)
 
 Finally, you can develop your own solution, complying with the interfaces
 described in chapter
-{%- include ref.html label="Interface to the GAP Help System" text="Interface to the GAP Help System" %}
+{% include ref.html label="Interface to the GAP Help System" text="Interface to the GAP Help System" %}
 of the GAP Reference Manual. There are
 certain technical issues with this approach, and we would advise you to
 contact us if you are considering it.
@@ -170,7 +170,7 @@ updates as follows:
 - Create a new archive. Note that you **must** change the
   version number of your package. Don't forget to adjust the PackageInfo.g
   file and maybe other files to the new version number (the new number must be
-  higher, as explained {%- include ref.html label="Version Numbers" text="here" %}). Also the
+  higher, as explained {% include ref.html label="Version Numbers" text="here" %}). Also the
   name of the archive file must be different from previous names.
   (Just choose a name
   which contains the package name and the version number, like
@@ -194,7 +194,7 @@ updates as follows:
 
 
 You may also wish to refer to the
-{%- include ref.html label="Package release checklists" text="package release checklists" %}
+{% include ref.html label="Package release checklists" text="package release checklists" %}
 in the GAP Reference Manual.
 
 ### Validating a `PackageInfo.g` File
@@ -207,4 +207,4 @@ This is used for loading the package into GAP and for a possible
 redistribution of the package via the GAP website.
 
 A basic check for such a file from within GAP is provided by the function
-{%- include ref.html label="ValidatePackageInfo" %}.
+{% include ref.html label="ValidatePackageInfo" %}.

--- a/packages/authors/variablenames.md
+++ b/packages/authors/variablenames.md
@@ -19,7 +19,7 @@ Firstly, new global variables should be introduced with one of the
 `DeclareGlobalVariable`, or, if this not
 suitable for some reason, set using `BindGlobal` rather than simple
 assignment. (See section
-{%- include ref.html label="Global Variables in the Library" text="Global Variables in the Library" %}
+{% include ref.html label="Global Variables in the Library" text="Global Variables in the Library" %}
 of the GAP Reference Manual for more
 information on these function)<br/>
 This will help ensure that any clashes cause error messages rather than wrong
@@ -96,15 +96,15 @@ Moving on to the documented names, the main rule here is that functions
 with "short" or "common" names, such as "Tail" or "NormalForm" should
 usually be Operations (or Attributes or Properties if appropriate). See
 chapter
-{%- include ref.html book="Tutorial" label="Operations and Methods" %}
+{% include ref.html book="Tutorial" label="Operations and Methods" %}
 of the GAP tutorial and chapter
-{%- include ref.html label="Creating New Objects" %}
+{% include ref.html label="Creating New Objects" %}
 of the GAP Reference Manual for more detail of these concepts. Even if you
 only plan one method, or you only plan to apply them to non-attribute storing
 objects, declaring them as Properties, Attributes or Operations will allow
 them to be used for unrelated purposes in other modules or packages, since
 GAP allows multiple declarations quite flexibly. Although see section
-{%- include ref.html label="Operations and Mathematical Terms" %}
+{% include ref.html label="Operations and Mathematical Terms" %}
 of the GAP Reference Manual for a discussion of the risks of overusing
 names.
 


### PR DESCRIPTION
If you go to https://www.gap-system.org/capabilities/groups , and look at the first sentence, you will notice there is no whitespace before every link. This seems to be a consistent problem, across much of the site.

The issue is the use of `{%-` , which eats whitespace, instead of `{%`, which leaves it in.

I've tried to make a pass over all links, and look for this issue. I haven't edited some cases (notably inside _includes/ref.html, and some code in index.md), as there there are a series of tags, and the whitespace removal is on purpose.

I will admit I didn't go and check every single line I editted, but I do a bunch of random spot checks, and they either looked the same (as they were at the start of a line), or were improved, and I thought changing all cases in 'natural text' was best, so if future people work by copying existing code, they will be copying the right formatting.

I'm not sure if this was actually done on purpose, or this style of formatting was done automatically and made some text look good, while messing up other text?