### PR TITLE
On `index.md`: change "install page" to "installation page"

### DIFF
--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ You can study and easily modify or extend it for your special use.
 
 The current version is
 [GAP {{site.data.release.version}}]({{ site.baseurl }}/install/) released on {{site.data.release.date}}
-and it can be obtained from our [install page]({{ site.baseurl }}/install/).
+and it can be obtained from our [installation page]({{ site.baseurl }}/install/).
 Changes from earlier versions are described in the
 [Release history](https://github.com/gap-system/gap/blob/master/CHANGES.md).
 


### PR DESCRIPTION
I think "installation" sounds better, and also the title of the installation page is "installation", so I think it's the more accurate one too.