### PR TITLE
Fix a file path in the default PR message when syncing website data

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -41,7 +41,7 @@ jobs:
           title: Sync data from GAP's GitHub release system
           body: >-
             Automatically created by a GitHub Actions workflow, using with the
-            GAP release script `dev/release/update_website.py`.
+            GAP release script `dev/releases/update_website.py`.
 
             You may wish to squash and merge this pull request, in order
             to give it a more descriptive commit message.


### PR DESCRIPTION
It seems the `dev/release` folder has been changed at some point to `dev/releases`.