### PR TITLE
Fix packages table

### DIFF
--- a/assets/js/loadPackageTable.js
+++ b/assets/js/loadPackageTable.js
@@ -119,62 +119,73 @@ function auto_search($dt){
     }
 }
 
-// define a table
-let table = new DataTable('#packageList', {
-    // get the json file
-    "ajax" : {
-        "url": "../assets/package-infos.json",
-        "dataSrc": function(dictData){
-          // as the json file is a dict for every package it is necessary it put all values into an array for Datatables to understand it
-            var arr = [];
-            for(var key in dictData){
-                arr.push(dictData[key]);
+// delay until page load
+$(function(){
+
+    // hide the no-javascript version of the table
+    $('#packageList-no-js').hide();
+
+    // show the javascript version of the table
+    $('#packageList').show();
+
+    // define a table
+    let table = new DataTable('#packageList', {
+        // get the json file
+        "ajax" : {
+            "url": "../assets/package-infos.json",
+            "dataSrc": function(dictData){
+              // as the json file is a dict for every package it is necessary it put all values into an array for Datatables to understand it
+                var arr = [];
+                for(var key in dictData){
+                    arr.push(dictData[key]);
+                }
+                return arr;
             }
-            return arr;
+        },
+        // define the columns shown in the table
+        columns : [
+            {
+                class: 'dt-control',
+                orderable: false,
+                data: null,
+                defaultContent: ''
+            },
+            { "data" : "PackageName"},
+            { "data" : "Version", width: '7em'},
+            { "data" : "Date",
+               render: function (data, type, row) {
+                           return convertDateFormat(data)
+                       }
+            },
+            // the following column is set to invisible and only there so the search picks up the additional text as well
+            { data: null, render: (data, type, row) => format(data), visible: false},
+            { "data" : "Subtitle"},
+        ],
+        // change the text for the search function to make it distinct to the page search function
+        language: {
+            search: 'Search table:'
+        },
+        searchHighlight: true,
+        initComplete: function( settings, json ) {
+            auto_search(this);
+        },
+        // set default number of packages shown
+        pageLength: 25,
+    });
+
+    // Add event listener for opening and closing details
+    table.on('click', 'td.dt-control', function (e) {
+        let tr = e.target.closest('tr');
+        let row = table.row(tr);
+    
+        if (row.child.isShown()) {
+            // This row is already open - close it
+            row.child.hide();
         }
-    },
-    // define the columns shown in the table
-    columns : [
-        {
-            class: 'dt-control',
-            orderable: false,
-            data: null,
-            defaultContent: ''
-        },
-        { "data" : "PackageName"},
-        { "data" : "Version", width: '7em'},
-        { "data" : "Date",
-           render: function (data, type, row) {
-                       return convertDateFormat(data)
-                   }
-        },
-        // the following column is set to invisible and only there so the search picks up the additional text as well
-        { data: null, render: (data, type, row) => format(data), visible: false},
-        { "data" : "Subtitle"},
-    ],
-    // change the text for the search function to make it distinct to the page search function
-    language: {
-        search: 'Search table:'
-    },
-    searchHighlight: true,
-    initComplete: function( settings, json ) {
-        auto_search(this);
-    },
-    // set default number of packages shown
-    pageLength: 25,
-});
+        else {
+            // Open this row
+            row.child(format(row.data())).show();
+        }
+    });
 
-// Add event listener for opening and closing details
-table.on('click', 'td.dt-control', function (e) {
-    let tr = e.target.closest('tr');
-    let row = table.row(tr);
-
-    if (row.child.isShown()) {
-        // This row is already open - close it
-        row.child.hide();
-    }
-    else {
-        // Open this row
-        row.child(format(row.data())).show();
-    }
 });

--- a/packages/index.md
+++ b/packages/index.md
@@ -10,9 +10,6 @@ permalink: /packages/
 <script src="{{ site.baseurl }}/assets/js/datatables.min.js?version=1"></script>
 
 <script type="module" src="{{ site.baseurl }}/assets/js/loadPackageTable.js?version=3"></script>
-<style>
-  .hide-no-js { display: none }
-</style>
 
 <!-- List of deposited packages -->
 There are {{ site.data.package-infos | size }} packages that are shipped with GAP {{site.data.release.version}}.
@@ -30,21 +27,12 @@ Note that newer versions might be available on the package websites.
 | Name | Version | Date | Subtitle |
 {: id="packageList-no-js" class="display"}
 
-|   | Name | Version | Date | | Subtitle |
+| | Name | Version | Date | | Subtitle |
 |-
-{% for namepkg in site.data.package-infos -%}{%- assign pkg = namepkg[1] -%}
-|   | [{{ pkg.PackageName }}]({{ pkg.PackageWWWHome }}) | {{ pkg.Version }} | {{ pkg.Date }} | | {{ pkg.Subtitle }} |
-{% endfor -%}
+| |      |         |      | |          |
 |=
-|   | Name | Version | Date | | Subtitle |
-{: id="packageList" class="display hide-no-js"}
-
-<script>
-$(function() {
-  $("#packageList-no-js").remove();
-  $("#packageList").removeClass("hide-no-js");
-});
-</script>
+| | Name | Version | Date | | Subtitle |
+{: id="packageList" class="display" style="display:none"}
 
 The table above is generated using the open source software [Datatables](https://datatables.net/).
 It requires JavaScript to enable all features and make all data available.


### PR DESCRIPTION
Fixes #381. Though, I'm not sure this is an optimal solution.

The problem with the current table is that first a 5-columns-wide is created (was changed in d437882e8bca7d46832c3f6758d0d39a4e38a163 to provide a non-JavaScript version of the table). The DataTables script, however, has 6 columns defined, and this doesn't mix well. This causes the missing cell in the table footer... and other things, like the missing "Subtitle" header.

The simplest fix of all would be to just insert the missing column between Date and Subtitle again. But then the non-javascript version of the table has an empty column to the left, and an empty column between Date and Subtitle.

What this PR does instead is created two copies of the table: one with 4 columns intended for non-JS, and one with 6 columns intended for JS. The second one is hidden by default, but once the page is loaded and JavaScript is available, it hides the first table and makes the second one visible.